### PR TITLE
Missing -- in oneliner readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is a simple Model Context Protocol (MCP) server that allows AI assistants t
 ### One-Line Setup
 
 ```bash
-claude mcp add gemini-cli npx -y gemini-mcp-tool
+claude mcp add gemini-cli -- npx -y gemini-mcp-tool
 ```
 
 ### Verify Installation


### PR DESCRIPTION
## Description
The guide in the README.md for the one-liner command should include the `--` syntax. Without it, you may encounter an error like the one below:
```
% claude mcp add gemini-cli npx -y gemini-mcp-tool
error: unknown option '-y'
```
Expected result:
```
% claude mcp add gemini-cli -- npx -y gemini-mcp-tool
Added stdio MCP server gemini-cli with command: npx -y gemini-mcp-tool to local config
```

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] My code follows the project's style
- [x] I have updated the documentation if needed

