### PR TITLE
feat: add MCP tool annotations to all 6 tools

### DIFF
--- a/src/tools/ask-gemini.tool.ts
+++ b/src/tools/ask-gemini.tool.ts
@@ -23,6 +23,11 @@ export const askGeminiTool: UnifiedTool = {
     description: "Execute 'gemini -p <prompt>' to get Gemini AI's response. Supports enhanced change mode for structured edit suggestions.",
   },
   category: 'gemini',
+  annotations: {
+    title: "Ask Gemini",
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
   execute: async (args, onProgress) => {
     const { prompt, model, sandbox, changeMode, chunkIndex, chunkCacheKey } = args; if (!prompt?.trim()) { throw new Error(ERROR_MESSAGES.NO_PROMPT_PROVIDED); }
   

--- a/src/tools/brainstorm.tool.ts
+++ b/src/tools/brainstorm.tool.ts
@@ -134,6 +134,11 @@ export const brainstormTool: UnifiedTool = {
     description: "Generate structured brainstorming prompt with methodology-driven ideation, domain context integration, and analytical evaluation framework",
   },
   category: 'gemini',
+  annotations: {
+    title: "Brainstorm",
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
   execute: async (args, onProgress) => {
     const {
       prompt,

--- a/src/tools/fetch-chunk.tool.ts
+++ b/src/tools/fetch-chunk.tool.ts
@@ -12,9 +12,9 @@ const inputSchema = z.object({
 export const fetchChunkTool: UnifiedTool = {
   name: 'fetch-chunk',
   description: 'Retrieves cached chunks from a changeMode response. Use this to get subsequent chunks after receiving a partial changeMode response.',
-  
+
   zodSchema: inputSchema,
-  
+
   prompt: {
     description: 'Fetch the next chunk of a response',
     arguments: [
@@ -25,8 +25,13 @@ export const fetchChunkTool: UnifiedTool = {
       }
     ]
   },
-  
+
   category: 'utility',
+  annotations: {
+    title: "Fetch Chunk",
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
   
   execute: async (args: any, onProgress?: (newOutput: string) => void): Promise<string> => {
     const { cacheKey, chunkIndex } = args;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -4,11 +4,28 @@ import { ToolArguments } from "../constants.js";
 import { ZodTypeAny, ZodError } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
+/**
+ * MCP Tool annotations per specification.
+ * @see https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/#annotations
+ */
+export interface ToolAnnotations {
+  /** Human-readable title for the tool */
+  title?: string;
+  /** If true, the tool does not modify its environment */
+  readOnlyHint?: boolean;
+  /** If true, the tool may perform destructive updates */
+  destructiveHint?: boolean;
+  /** If true, repeated calls with same args have no additional effect */
+  idempotentHint?: boolean;
+  /** If true, the tool interacts with external entities */
+  openWorldHint?: boolean;
+}
+
 export interface UnifiedTool {
   name: string;
   description: string;
   zodSchema: ZodTypeAny;
-  
+
   prompt?: {
     description: string;
     arguments?: Array<{
@@ -17,9 +34,11 @@ export interface UnifiedTool {
       required: boolean;
     }>;
   };
-  
+
   execute: (args: ToolArguments, onProgress?: (newOutput: string) => void) => Promise<string>;
   category?: 'simple' | 'gemini' | 'utility';
+  /** MCP tool annotations for AI assistants */
+  annotations?: ToolAnnotations;
 }
 
 export const toolRegistry: UnifiedTool[] = [];
@@ -35,12 +54,19 @@ export function getToolDefinitions(): Tool[] { // get Tool definitions from regi
       properties: def.properties || {},
       required: def.required || [],
     };
-    
-    return {
+
+    const toolDef: Tool = {
       name: tool.name,
       description: tool.description,
       inputSchema,
     };
+
+    // Include annotations if defined
+    if (tool.annotations) {
+      toolDef.annotations = tool.annotations;
+    }
+
+    return toolDef;
   });
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -55,18 +55,12 @@ export function getToolDefinitions(): Tool[] { // get Tool definitions from regi
       required: def.required || [],
     };
 
-    const toolDef: Tool = {
+    return {
       name: tool.name,
       description: tool.description,
       inputSchema,
+      annotations: tool.annotations,
     };
-
-    // Include annotations if defined
-    if (tool.annotations) {
-      toolDef.annotations = tool.annotations;
-    }
-
-    return toolDef;
   });
 }
 

--- a/src/tools/simple-tools.ts
+++ b/src/tools/simple-tools.ts
@@ -14,6 +14,11 @@ export const pingTool: UnifiedTool = {
     description: "Echo test message with structured response.",
   },
   category: 'simple',
+  annotations: {
+    title: "Ping",
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
   execute: async (args, onProgress) => {
     const message = args.prompt || args.message || "Pong!";
     return executeCommand("echo", [message as string], onProgress);
@@ -30,6 +35,11 @@ export const helpTool: UnifiedTool = {
     description: "receive help information",
   },
   category: 'simple',
+  annotations: {
+    title: "Help",
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
   execute: async (args, onProgress) => {
     return executeCommand("gemini", ["-help"], onProgress);
   }

--- a/src/tools/timeout-test.tool.ts
+++ b/src/tools/timeout-test.tool.ts
@@ -13,6 +13,10 @@ export const timeoutTestTool: UnifiedTool = {
     description: "Test the timeout prevention system by running a long operation",
   },
   category: 'simple',
+  annotations: {
+    title: "Timeout Test",
+    readOnlyHint: true,
+  },
   execute: async (args, onProgress) => {
     const duration = args.duration as number;
     const steps = Math.ceil(duration / 5000); // Progress every 5 seconds


### PR DESCRIPTION
## Summary
- Add MCP tool annotations to all 6 tools per [MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/#annotations)
- Annotations help AI assistants understand tool behavior and capabilities
- Added `ToolAnnotations` interface and updated `UnifiedTool` interface

## Changes

### Infrastructure
- Added `ToolAnnotations` interface to `registry.ts` with all MCP-spec fields
- Extended `UnifiedTool` interface with optional `annotations` property
- Updated `getToolDefinitions()` to include annotations in Tool output

### Tools Annotated

| Tool | readOnlyHint | openWorldHint | idempotentHint |
|------|--------------|---------------|----------------|
| `ask-gemini` | true | true | - |
| `brainstorm` | true | true | - |
| `Help` | true | true | - |
| `ping` | true | - | true |
| `fetch-chunk` | true | - | true |
| `timeout-test` | true | - | - |

**All tools are read-only** - they query external services or return cached data but don't modify state.

## Test plan
- [x] TypeScript builds without errors
- [x] Annotations follow MCP spec naming conventions
- [x] Tools with external API access marked `openWorldHint: true`
- [x] Idempotent tools (ping, cache retrieval) marked `idempotentHint: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)