### PR TITLE
fix: use positional prompt argument instead of deprecated -p flag

### DIFF
--- a/src/tools/ask-gemini.tool.ts
+++ b/src/tools/ask-gemini.tool.ts
@@ -20,7 +20,7 @@ export const askGeminiTool: UnifiedTool = {
   description: "model selection [-m], sandbox [-s], and changeMode:boolean for providing edits",
   zodSchema: askGeminiArgsSchema,
   prompt: {
-    description: "Execute 'gemini -p <prompt>' to get Gemini AI's response. Supports enhanced change mode for structured edit suggestions.",
+    description: "Execute 'gemini <prompt>' to get Gemini AI's response. Supports enhanced change mode for structured edit suggestions.",
   },
   category: 'gemini',
   execute: async (args, onProgress) => {

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -96,7 +96,8 @@ ${prompt_processed}
     ? `"${prompt_processed}"` 
     : prompt_processed;
     
-  args.push(CLI.FLAGS.PROMPT, finalPrompt);
+  // Use positional argument instead of deprecated -p flag (removed in Gemini CLI v0.23.0+)
+  args.push('--', finalPrompt);
   
   try {
     return await executeCommand(CLI.COMMANDS.GEMINI, args, onProgress);
@@ -116,7 +117,8 @@ ${prompt_processed}
         ? `"${prompt_processed}"` 
         : prompt_processed;
         
-      fallbackArgs.push(CLI.FLAGS.PROMPT, fallbackPrompt);
+      // Use positional argument instead of deprecated -p flag
+      fallbackArgs.push('--', fallbackPrompt);
       try {
         const result = await executeCommand(CLI.COMMANDS.GEMINI, fallbackArgs, onProgress);
         Logger.warn(`Successfully executed with ${MODELS.FLASH} fallback.`);


### PR DESCRIPTION
## Problem

Gemini CLI v0.23.0+ deprecated the `-p`/`--prompt` flag. Using it now produces:

```
Cannot use both a positional prompt and the --prompt (-p) flag together
```

## Fix

Replace `args.push(CLI.FLAGS.PROMPT, finalPrompt)` with `args.push('--', finalPrompt)` to use the prompt as a positional argument. Applied to both the primary and fallback (quota exceeded) execution paths.

Fixes #48