### PR TITLE
fix: remove incorrect prompt quoting for spawn(shell=false)

### DIFF
--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -91,10 +91,8 @@ ${prompt_processed}
   if (model) { args.push(CLI.FLAGS.MODEL, model); }
   if (sandbox) { args.push(CLI.FLAGS.SANDBOX); }
   
-  // Ensure @ symbols work cross-platform by wrapping in quotes if needed
-  const finalPrompt = prompt_processed.includes('@') && !prompt_processed.startsWith('"') 
-    ? `"${prompt_processed}"` 
-    : prompt_processed;
+  // spawn() uses shell: false — arguments are passed directly, no quoting needed
+  const finalPrompt = prompt_processed;
     
   args.push(CLI.FLAGS.PROMPT, finalPrompt);
   
@@ -111,10 +109,8 @@ ${prompt_processed}
         fallbackArgs.push(CLI.FLAGS.SANDBOX);
       }
       
-      // Same @ symbol handling for fallback
-      const fallbackPrompt = prompt_processed.includes('@') && !prompt_processed.startsWith('"') 
-        ? `"${prompt_processed}"` 
-        : prompt_processed;
+      // Same direct argument passing for fallback
+      const fallbackPrompt = prompt_processed;
         
       fallbackArgs.push(CLI.FLAGS.PROMPT, fallbackPrompt);
       try {


### PR DESCRIPTION
`spawn()` with `shell: false` passes arguments directly to the OS process without shell interpretation. Wrapping prompts containing `@` in double quotes adds **literal** quote characters to the prompt text.

## Problem

```typescript
// Before: adds literal "..." around the prompt
const finalPrompt = prompt_processed.includes('@') && !prompt_processed.startsWith('"') 
    ? `"${prompt_processed}"` 
    : prompt_processed;
```

`commandExecutor.ts` uses `spawn(command, args, { shell: false })`. With `shell: false`, the `"` characters are passed as literal characters in the argument. The Gemini CLI receives the prompt text **including** the double quotes.

## Fix

Remove the quoting entirely since `spawn(shell: false)` doesn't need it — each array element is passed as a single argument directly to the process.

Same fix applied to the fallback/retry path.

Fixes #66