### PR TITLE
Fix spawn EINVAL on Windows + Node 22+ for .cmd shims

### DIFF
--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -10,9 +10,24 @@ export async function executeCommand(
     const startTime = Date.now();
     Logger.commandExecution(command, args, startTime);
 
-    const childProcess = spawn(command, args, {
+    // Windows quirk: Node 22+ blocks spawning `.cmd` / `.bat` shims without
+    // `shell: true` (CVE-2024-27980). But `shell: true` causes cmd.exe to
+    // re-tokenise the argument list on whitespace, which mangles any prompt
+    // that contains spaces (Gemini sees `-p Hello` plus stray positionals
+    // `world.`). The fix is to enable the shell on Windows AND wrap any arg
+    // containing whitespace or a double quote in cmd.exe-safe quotes
+    // (internal `"` is escaped as `""`). This is a no-op on macOS / Linux.
+    const isWindows = process.platform === "win32";
+    const safeArgs = isWindows
+      ? args.map(a => {
+          const s = String(a);
+          return /[\s"]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+        })
+      : args;
+
+    const childProcess = spawn(command, safeArgs, {
       env: process.env,
-      shell: false,
+      shell: isWindows,
       stdio: ["ignore", "pipe", "pipe"],
     });
 


### PR DESCRIPTION
## Summary

`spawn` fails on Windows + Node ≥ 22 because Node's [CVE-2024-27980](https://nvd.nist.gov/vuln/detail/CVE-2024-27980) hardening blocks `child_process.spawn` from launching `.cmd`/`.bat` shims without `shell: true`. Since `gemini` is published as `gemini.cmd` on Windows, every `executeCommand("gemini", ...)` call from `gemini-mcp-tool` raises `spawn EINVAL`.

The naive fix — flipping `shell: true` — introduces a second bug: `cmd.exe` re-tokenises the args array on whitespace, splitting prompts that contain spaces into multiple positional args. For example, `["-p", "Reply READY only."]` becomes the command line `gemini -p Reply READY only.`, which Gemini 0.40+ rejects with:

> Cannot use both a positional prompt and the --prompt (-p) flag together

This PR applies both fixes in tandem, on Windows only. macOS and Linux paths are unchanged.

## Repro on Windows + Node ≥ 22 + gemini-cli ≥ 0.40

```
> ask-gemini "Reply READY only."
Error executing ask-gemini: spawn EINVAL
```

## After this PR

```
> ask-gemini "Reply READY only."
Gemini response:
READY
```

## Why this isn't just `shell: true`

Four Windows + Node 24.14 failure modes I worked through end-to-end before landing on this fix:

| Approach | Result |
|---|---|
| Original (`shell: false`) | `spawn gemini ENOENT` (Node < 22) or `spawn EINVAL` (Node ≥ 22) |
| Patch attempt 1: `shell: true` only | `cmd.exe` splits prompt on whitespace → "Cannot use both a positional prompt and the --prompt (-p) flag together" |
| Patch attempt 2: `shell: false` + explicit `.cmd` extension on `command` | Blocked by CVE-2024-27980 hardening → `spawn EINVAL` |
| **This PR**: `shell: true` + cmd-safe quoting on Windows args | All three failure modes resolved |

## Code change

Single function in `src/utils/commandExecutor.ts`. Behaviour preserved exactly on macOS / Linux — `safeArgs === args`, `shell: false`. The platform branch wraps any arg containing whitespace or a double quote in `cmd.exe`-safe quotes (internal `"` escaped as `""`).

## Testing

- **macOS / Linux**: `safeArgs === args`, `shell: false` — no behavioural change.
- **Windows + Node 24.14.1**: end-to-end verified in a real Claude Code MCP wiring against `gemini-cli` 0.40.1. `ask-gemini` and `ping` both responding correctly (`ping` works because `cmd.exe` has a built-in `echo`).
- **TypeScript**: `npx tsc --noEmit` clean.

## References

- [CVE-2024-27980](https://nvd.nist.gov/vuln/detail/CVE-2024-27980)
- [Node.js April 2024 security release](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2) — the upstream change that made this surface on Windows
