### PR TITLE
fix(security): CVE-2026-0755 — remove broken prompt quoting & contain @file refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+- Security fix: OS command-injection / `@file` exfiltration via prompt quoting in `geminiExecutor.ts` (CVE-2026-0755, CWE-78). Fixes #73 (and the literal-quote corruption in #66).
+  - Removed the broken double-quote wrapping from both the primary and fallback paths. With `spawn` running `shell: false`, those quotes were passed as literal characters — they provided no protection and corrupted `@file` references. Windows `.cmd` quoting is already handled safely in `commandExecutor.ts`.
+  - Added `assertSafeFileReferences()`, which rejects any `@file` reference that resolves outside the project working directory (absolute paths, `~` home references, and `../` traversal), closing the arbitrary-file-read exfiltration vector while preserving legitimate in-project `@file` usage.
 - Fixed `spawn EINVAL` error on Windows with Node 22+ when launching `.cmd` shims (PR #69).
 
 ## [1.1.5]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [Unreleased]
 - Security fix: OS command-injection / `@file` exfiltration via prompt quoting in `geminiExecutor.ts` (CVE-2026-0755, CWE-78). Fixes #73 (and the literal-quote corruption in #66).
-  - Removed the broken double-quote wrapping from both the primary and fallback paths. With `spawn` running `shell: false`, those quotes were passed as literal characters — they provided no protection and corrupted `@file` references. Windows `.cmd` quoting is already handled safely in `commandExecutor.ts`.
+  - Removed the broken double-quote wrapping from both the primary and fallback paths. With `spawn` running `shell: false`, those quotes were passed as literal characters — they provided no protection and corrupted `@file` references. Windows `.cmd` argument quoting is hardened separately (see below).
   - Added `assertSafeFileReferences()`, which rejects any `@file` reference that resolves outside the project working directory (absolute paths, `~` home references, and `../` traversal), closing the arbitrary-file-read exfiltration vector while preserving legitimate in-project `@file` usage.
+  - Hardened the Windows `shell: true` path in `commandExecutor.ts`: every argument is now quoted (previously only those containing whitespace), so cmd metacharacters (`& | < > ^ ( )`) in spaceless tokens such as `a&calc` can no longer break out into command injection. Affected every tool that shells out (`ask-gemini`, `brainstorm`, `ping`).
 - Fixed `spawn EINVAL` error on Windows with Node 22+ when launching `.cmd` shims (PR #69).
 
 ## [1.1.5]

--- a/SECURITY-REPORT-2026-05-28.md
+++ b/SECURITY-REPORT-2026-05-28.md
@@ -1,0 +1,92 @@
+# Security Report — gemini-mcp-tool
+
+- **Date:** 2026-05-28
+- **Repository:** `jamubc/gemini-mcp-tool`
+- **Branch reviewed:** `security/cve-2026-0755` (PR #75)
+- **Scope:** All hand-written source under `src/`, plus declared npm dependencies.
+- **Method:** Manual code review + sink analysis (`child_process` / `fs` / network / `eval`), `npm audit` with runtime-vs-dev tree attribution, and a cross-check of open GitHub issues.
+
+> No security issue was filed today (2026-05-28). The most recent security report is **#73 (CVE-2026-0755)**, which is fixed on this branch (PR #75).
+
+---
+
+## Executive summary
+
+| Area         | Critical | High | Moderate | Low / Info |
+|--------------|:--------:|:----:|:--------:|:----------:|
+| Code         | 1 (fixed)| 0    | 0        | 4          |
+| Dependencies | 0        | 8*   | 15       | 2          |
+
+\* Only **2 of the 8 dependency HIGHs reach the published/runtime tree** (`@modelcontextprotocol/sdk`, and `tmp` via the unused `inquirer` dep). The other 6 HIGHs live exclusively in the docs/build toolchain (`vitepress`, `mermaid`, `archiver`) and are never installed for end users.
+
+---
+
+## Code findings
+
+### C1 — CVE-2026-0755: OS command-injection / `@file` exfiltration — **Critical — FIXED (PR #75)**
+`geminiExecutor.ts` wrapped any prompt containing `@` in literal `"` before passing it to `spawn` (`shell: false`), which injected literal quote characters and corrupted `@file` references, while leaving an arbitrary-file-read vector through the Gemini CLI's `@file` parser.
+
+**Fix (this branch):** removed the broken quoting from the primary and fallback paths; added `assertSafeFileReferences()` which rejects `@file` references that resolve outside the project working directory (absolute, `~`, and `../` traversal). The guard runs on the fully-processed prompt, so it also protects the `brainstorm` and `changeMode` code paths.
+
+### C2 — Windows `cmd.exe` variable expansion in prompts — **Low (Windows-only)**
+`commandExecutor.ts` uses `shell: true` on Windows and wraps whitespace/quote args in `"..."` (escaping `"`→`""`). `cmd.exe` still expands `%VAR%` **inside** double quotes, so a prompt containing e.g. `%USERNAME%` / `%PATH%` is substituted before reaching `gemini`. This is not a command-execution break-out, but it is a correctness + minor information-substitution issue. Unix is unaffected (`shell: false`).
+**Recommendation:** adopt the issue #62 approach — spawn `process.execPath` with the resolved `gemini.js` path and `shell: false` on Windows too — eliminating the shell (and the quoting fragility) entirely.
+
+### C3 — Verbose logging of full tool arguments / prompts — **Low / Informational**
+`logger.ts` logs raw args via `JSON.stringify` on every invocation (`Logger.toolInvocation`), and `Logger.debug` is wired to `console.warn`, so prompt bodies are written to stderr **regardless of any debug flag**. Prompts may contain pasted file contents or secrets; on shared hosts or captured MCP logs this is a disclosure risk.
+**Recommendation:** gate full-argument logging behind an explicit debug env var; avoid logging full prompt bodies at the default level.
+
+### C4 — Raw `error.message` returned to client — **Informational**
+`index.ts` returns `Error executing ${tool}: ${error.message}`. CLI/`fs` errors may embed absolute local paths. Low impact for a local stdio server; noted for completeness.
+
+### C5 — Unbounded lazy regex over model output — **Informational**
+`changeModeParser.ts` uses `[\s\S]*?` groups. Input is Gemini's *response* (model-controlled, not direct attacker network input), so ReDoS exposure is low. Acceptable today; revisit if these inputs ever become untrusted.
+
+### Positives observed
+- `commandExecutor.ts` uses `spawn` with `shell: false` on Unix and an args array — no shell injection.
+- #72 path-traversal hardening on `cacheKey` is solid: format regex (`/^[a-f0-9]{8}$/`) + `path.resolve` containment + removal of the silent `unlink` primitive.
+- All tool arguments are validated through `zod` before execution.
+- The server is **stdio-only** — there is no network listener by default.
+
+---
+
+## Dependency findings
+
+`npm audit`: **25 vulnerabilities (8 high, 15 moderate, 2 low)**. The published package ships only `dist/`, but its `dependencies` are installed transitively for every end user, so the runtime-vs-dev split below is what actually matters.
+
+### D1 — `@modelcontextprotocol/sdk@0.5.0` — **High — runtime, USED**
+- Advisories: ReDoS (high); "DNS-rebinding protection not enabled by default" (high).
+- **DNS rebinding does not apply** here: this server uses `StdioServerTransport`, not the Streamable-HTTP transport the advisory concerns.
+- ReDoS applies to SDK message handling; with a trusted local stdio client, exposure is limited but real.
+- `0.5.0` is far behind the current `1.x` line. **Upgrading is recommended but is a breaking API change** and will require edits to `index.ts`.
+
+### D2 — `inquirer@9.3.7` → `external-editor` → `tmp@0.0.33` — **High path traversal — runtime, UNUSED**
+- `inquirer`, `ai`, `chalk`, `d3-shape`, and `prismjs` are declared as runtime `dependencies` but are **not imported anywhere in `src/`**. They are still installed for every user, and `inquirer` drags in the HIGH `tmp` path-traversal advisory.
+- **Recommendation (high value, low effort):** remove these unused runtime deps. This eliminates the only runtime-tree HIGH besides the SDK and significantly shrinks install/attack surface. (Note: `package.json` references a `contribute` script at `src/contribute.ts` which does not exist in the tree — confirm nothing relies on these before removal.)
+
+### D3 — Docs/build toolchain HIGHs — **Not shipped, lower priority**
+All remaining HIGHs are confined to `devDependencies` and are not installed for end users or used by the running server:
+- `archiver` → `glob`, `minimatch`, `lodash`
+- `vitepress` → `rollup`, `vite`, `esbuild`, `preact`
+- `mermaid` → `dompurify`
+
+Patch opportunistically with `npm audit fix`, but these do not affect deployed MCP servers.
+
+---
+
+## Additional observations (full source-tree read)
+
+These do **not** affect the published npm package or the running MCP server (the docs site is built/deployed separately to GitHub Pages), but are noted for completeness:
+
+- **Docs site loads a third-party ad script.** `docs/.vitepress/theme/components/AdBanner.vue` injects `//cdn.carbonads.com/carbon.js` into the page `<head>`. It is currently an inert placeholder (`serve=YOUR_CARBON_ID`), but any third-party script on the docs origin is a supply-chain/privacy consideration. *(Informational — docs site only.)*
+- **`v-html` in `CodeBlock.vue`.** Renders Prism-highlighted output via `v-html`. Input is build-time-authored doc content and Prism escapes HTML, so this is not an exploitable XSS today. *(Informational — docs site only.)*
+- **Dead / duplicate files.** `src/utils/timeoutManager.ts` is effectively empty (1 line) and imported nowhere; `src/scripts/deploy-wiki.sh` is a byte-for-byte duplicate of `scripts/deploy-wiki.sh`. Housekeeping, not security — safe to remove.
+
+## Prioritized recommendations
+
+1. **Merge PR #75** — CVE-2026-0755 fix. *(Critical — done, pending merge.)*
+2. **Remove unused runtime deps** (`ai`, `chalk`, `d3-shape`, `inquirer`, `prismjs`) — removes the `tmp` HIGH from the shipped tree. *(High, low effort.)*
+3. **Plan `@modelcontextprotocol/sdk` 0.5 → 1.x upgrade.** *(High, breaking — needs code changes.)*
+4. **Gate verbose prompt/argument logging** behind a debug flag. *(Low.)*
+5. **Windows:** drop `shell: true` in favor of the node + `gemini.js` approach (issue #62) to remove `%VAR%` expansion and quoting fragility. *(Low.)*
+6. **`npm audit fix`** for the docs/build toolchain. *(Low.)*

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -1,6 +1,15 @@
 import { spawn } from "child_process";
 import { Logger } from "./logger.js";
 
+// Quote a single argument for cmd.exe (used by spawn's shell:true on Windows).
+// Embedded quotes are doubled and backslash runs before a quote (or the closing
+// quote) are doubled so they don't escape it, per CommandLineToArgvW rules. Note
+// cmd still expands %VAR%/!VAR! inside quotes — an env read at worst, not RCE.
+function quoteForCmd(arg: string): string {
+  const body = String(arg).replace(/(\\*)"/g, '$1$1""').replace(/(\\+)$/, '$1$1');
+  return `"${body}"`;
+}
+
 export async function executeCommand(
   command: string,
   args: string[],
@@ -11,19 +20,14 @@ export async function executeCommand(
     Logger.commandExecution(command, args, startTime);
 
     // Windows quirk: Node 22+ blocks spawning `.cmd` / `.bat` shims without
-    // `shell: true` (CVE-2024-27980). But `shell: true` causes cmd.exe to
-    // re-tokenise the argument list on whitespace, which mangles any prompt
-    // that contains spaces (Gemini sees `-p Hello` plus stray positionals
-    // `world.`). The fix is to enable the shell on Windows AND wrap any arg
-    // containing whitespace or a double quote in cmd.exe-safe quotes
-    // (internal `"` is escaped as `""`). This is a no-op on macOS / Linux.
+    // `shell: true` (CVE-2024-27980). But shell:true routes the command through
+    // cmd.exe, which re-parses the joined line — so EVERY argument must be
+    // quoted, not just those with whitespace. cmd metacharacters (& | < > ^ ( ))
+    // trigger command injection even in tokens without spaces (e.g. a prompt
+    // `a&calc`); wrapping each arg in double quotes makes them inert. This is a
+    // no-op on macOS / Linux, where shell:false passes argv directly.
     const isWindows = process.platform === "win32";
-    const safeArgs = isWindows
-      ? args.map(a => {
-          const s = String(a);
-          return /[\s"]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-        })
-      : args;
+    const safeArgs = isWindows ? args.map(quoteForCmd) : args;
 
     const childProcess = spawn(command, safeArgs, {
       env: process.env,

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { executeCommand } from './commandExecutor.js';
 import { Logger } from './logger.js';
 import { 
@@ -11,6 +12,36 @@ import { parseChangeModeOutput, validateChangeModeEdits } from './changeModePars
 import { formatChangeModeResponse, summarizeChangeModeEdits } from './changeModeTranslator.js';
 import { chunkChangeModeEdits } from './changeModeChunker.js';
 import { cacheChunks, getChunks } from './chunkCache.js';
+
+const FILE_REF_PATTERN = /@(\S+)/g;
+
+/**
+ * Rejects @file references that resolve outside the working directory.
+ *
+ * The Gemini CLI inlines the contents of any `@path` token it finds in the
+ * prompt. Because prompt text can originate from untrusted input, an
+ * unrestricted reference such as `@/etc/passwd`, `@~/.ssh/id_rsa` or
+ * `@../../secret` would let that input exfiltrate arbitrary local files
+ * (CVE-2026-0755). Constraining references to the project root preserves the
+ * legitimate `@file` feature while removing the exfiltration primitive.
+ */
+export function assertSafeFileReferences(prompt: string, root: string = process.cwd()): void {
+  const normalizedRoot = path.resolve(root);
+  for (const match of prompt.matchAll(FILE_REF_PATTERN)) {
+    const ref = match[1];
+    const resolved = path.resolve(normalizedRoot, ref);
+    const escapesRoot =
+      resolved !== normalizedRoot && !resolved.startsWith(normalizedRoot + path.sep);
+    // `~` is rejected explicitly: path.resolve treats it as a literal segment,
+    // so a home-directory reference would otherwise look contained.
+    if (ref.startsWith('~') || escapesRoot) {
+      throw new Error(
+        `Refusing @file reference outside the project directory: "@${ref}". ` +
+        `Only files within ${normalizedRoot} may be referenced.`
+      );
+    }
+  }
+}
 
 export async function executeGeminiCLI(
   prompt: string,
@@ -86,18 +117,21 @@ ${prompt_processed}
 `;
     prompt_processed = changeModeInstructions;
   }
-  
+
+  // Block @file references that escape the project root before the prompt
+  // reaches the Gemini CLI's file-inlining parser (CVE-2026-0755).
+  assertSafeFileReferences(prompt_processed);
+
   const args = [];
   if (model) { args.push(CLI.FLAGS.MODEL, model); }
   if (sandbox) { args.push(CLI.FLAGS.SANDBOX); }
-  
-  // Ensure @ symbols work cross-platform by wrapping in quotes if needed
-  const finalPrompt = prompt_processed.includes('@') && !prompt_processed.startsWith('"') 
-    ? `"${prompt_processed}"` 
-    : prompt_processed;
-    
-  args.push(CLI.FLAGS.PROMPT, finalPrompt);
-  
+
+  // spawn runs with shell: false (and cmd.exe-safe quoting on Windows is
+  // handled in commandExecutor), so the prompt is passed verbatim as a single
+  // argv entry. No manual quoting here — wrapping in `"` only injects literal
+  // quote characters and corrupts @file references (#66, CVE-2026-0755).
+  args.push(CLI.FLAGS.PROMPT, prompt_processed);
+
   try {
     return await executeCommand(CLI.COMMANDS.GEMINI, args, onProgress);
   } catch (error) {
@@ -111,12 +145,8 @@ ${prompt_processed}
         fallbackArgs.push(CLI.FLAGS.SANDBOX);
       }
       
-      // Same @ symbol handling for fallback
-      const fallbackPrompt = prompt_processed.includes('@') && !prompt_processed.startsWith('"') 
-        ? `"${prompt_processed}"` 
-        : prompt_processed;
-        
-      fallbackArgs.push(CLI.FLAGS.PROMPT, fallbackPrompt);
+      // Pass the prompt verbatim here too (see note in the primary path).
+      fallbackArgs.push(CLI.FLAGS.PROMPT, prompt_processed);
       try {
         const result = await executeCommand(CLI.COMMANDS.GEMINI, fallbackArgs, onProgress);
         Logger.warn(`Successfully executed with ${MODELS.FLASH} fallback.`);


### PR DESCRIPTION
## Summary

Fixes #73 (CVE-2026-0755 / CWE-78) and the literal-quote corruption in #66.

`geminiExecutor.ts` wrapped any prompt containing `@` in literal double quotes before pushing it into the `spawn` args array:

```ts
const finalPrompt = prompt_processed.includes('@') && !prompt_processed.startsWith('"')
    ? `"${prompt_processed}"`
    : prompt_processed;
args.push(CLI.FLAGS.PROMPT, finalPrompt);
```

Because `commandExecutor.ts` runs `spawn` with `shell: false` (on Windows it uses `shell: true` but already applies its own cmd.exe‑safe quoting), these quotes are passed to the Gemini CLI as **literal characters**. They provided zero shell protection and actively corrupted `@file` references. The residual risk is that untrusted prompt input reaching the CLI's `@file` parser can exfiltrate arbitrary local files.

## Changes

1. **Remove the broken quoting** from both the primary and fallback paths — the prompt is now passed verbatim as a single argv entry, which is correct under `shell: false`. This also fixes the literal‑quote corruption reported in #66.
2. **Add `assertSafeFileReferences()`** — runs before the prompt reaches the CLI and rejects any `@file` reference that resolves **outside the project working directory**:
   - absolute paths (`@/etc/passwd`)
   - home references (`@~/.ssh/id_rsa`)
   - parent/traversal escapes (`@../../secret`, `@src/../../etc/passwd`)

   Legitimate in‑project references (`@src/index.ts explain this`) keep working, so the headline `@file` feature is preserved. The containment check mirrors the `path.resolve` + `startsWith(root + path.sep)` approach already used in the #72 cache path‑traversal fix.

## Why containment instead of stripping all `@`

The issue suggested stripping every `@`-prefixed token. That would fully close the vector but also break the tool's primary advertised feature (file analysis via `@` syntax — see `ask-gemini.tool.ts`, the error messages, and the CHANGELOG). Restricting references to the project root removes the arbitrary‑file‑read primitive while keeping the feature usable.

## Test plan

- [x] `npm run build` (tsc) passes.
- [x] Behavior verified against legitimate and malicious prompts via `tsx`:
  - allowed: `@src/index.ts ...`, `@./src/utils/logger.ts`, `john@example.com`, trailing punctuation, `@.`, no‑ref prompts
  - blocked: `@/etc/passwd`, `@~/.ssh/id_rsa`, `@../../../etc/shadow`, `@../sibling/secret.env`, `@src/../../etc/passwd`
- [ ] Manual smoke test against a real `gemini` CLI install (not available in CI env).
---