### PR TITLE
feat(windows): stdin prompt passing + windowsHide (harvested from #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Removed the broken double-quote wrapping from both the primary and fallback paths. With `spawn` running `shell: false`, those quotes were passed as literal characters — they provided no protection and corrupted `@file` references. Windows `.cmd` argument quoting is hardened separately (see below).
   - Added `assertSafeFileReferences()`, which rejects any `@file` reference that resolves outside the project working directory (absolute paths, `~` home references, and `../` traversal), closing the arbitrary-file-read exfiltration vector while preserving legitimate in-project `@file` usage.
   - Hardened the Windows `shell: true` path in `commandExecutor.ts`: every argument is now quoted (previously only those containing whitespace), so cmd metacharacters (`& | < > ^ ( )`) in spaceless tokens such as `a&calc` can no longer break out into command injection. Affected every tool that shells out (`ask-gemini`, `brainstorm`, `ping`).
+- Windows robustness: complex prompts (`changeMode` / `@file`) are now sent to the Gemini CLI on **stdin** instead of the `-p` flag, sidestepping cmd.exe argument parsing and the OS command-line length limit on large prompts. Added `windowsHide` to suppress the popup console window on Windows. (Harvested from the tested work in #27.)
 - Fixed `spawn EINVAL` error on Windows with Node 22+ when launching `.cmd` shims (PR #69).
 
 ## [1.1.5]

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -13,7 +13,8 @@ function quoteForCmd(arg: string): string {
 export async function executeCommand(
   command: string,
   args: string[],
-  onProgress?: (newOutput: string) => void
+  onProgress?: (newOutput: string) => void,
+  stdinData?: string,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
@@ -29,18 +30,27 @@ export async function executeCommand(
     const isWindows = process.platform === "win32";
     const safeArgs = isWindows ? args.map(quoteForCmd) : args;
 
+    // Complex prompts arrive on stdin (see geminiExecutor) to bypass cmd.exe
+    // parsing and the OS command-line length limit; only open stdin then.
+    // windowsHide suppresses the popup console window on Windows (no-op elsewhere).
     const childProcess = spawn(command, safeArgs, {
       env: process.env,
       shell: isWindows,
-      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      stdio: [stdinData !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
     });
+
+    if (stdinData !== undefined && childProcess.stdin) {
+      childProcess.stdin.write(stdinData);
+      childProcess.stdin.end();
+    }
 
     let stdout = "";
     let stderr = "";
     let isResolved = false;
     let lastReportedLength = 0;
     
-    childProcess.stdout.on("data", (data) => {
+    childProcess.stdout?.on("data", (data) => {
       stdout += data.toString();
       
       // Report new content if callback provided
@@ -53,7 +63,7 @@ export async function executeCommand(
 
 
     // CLI level errors
-    childProcess.stderr.on("data", (data) => {
+    childProcess.stderr?.on("data", (data) => {
       stderr += data.toString();
       // find RESOURCE_EXHAUSTED when gemini-2.5-pro quota is exceeded
       if (stderr.includes("RESOURCE_EXHAUSTED")) {

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -126,14 +126,16 @@ ${prompt_processed}
   if (model) { args.push(CLI.FLAGS.MODEL, model); }
   if (sandbox) { args.push(CLI.FLAGS.SANDBOX); }
 
-  // spawn runs with shell: false (and cmd.exe-safe quoting on Windows is
-  // handled in commandExecutor), so the prompt is passed verbatim as a single
-  // argv entry. No manual quoting here — wrapping in `"` only injects literal
-  // quote characters and corrupts @file references (#66, CVE-2026-0755).
-  args.push(CLI.FLAGS.PROMPT, prompt_processed);
+  // changeMode and @file prompts go on stdin instead of -p: keeps large prompts
+  // under the OS command-line length limit and never exposes them to cmd.exe
+  // parsing on Windows. Simple prompts use -p verbatim (commandExecutor handles
+  // Windows quoting); no manual quoting — that only injects literal quote
+  // characters and corrupts @file references (#66, CVE-2026-0755).
+  const useStdin = !!changeMode || prompt_processed.includes('@');
+  if (!useStdin) { args.push(CLI.FLAGS.PROMPT, prompt_processed); }
 
   try {
-    return await executeCommand(CLI.COMMANDS.GEMINI, args, onProgress);
+    return await executeCommand(CLI.COMMANDS.GEMINI, args, onProgress, useStdin ? prompt_processed : undefined);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (errorMessage.includes(ERROR_MESSAGES.QUOTA_EXCEEDED) && model !== MODELS.FLASH) {
@@ -145,10 +147,10 @@ ${prompt_processed}
         fallbackArgs.push(CLI.FLAGS.SANDBOX);
       }
       
-      // Pass the prompt verbatim here too (see note in the primary path).
-      fallbackArgs.push(CLI.FLAGS.PROMPT, prompt_processed);
+      // Same stdin/-p routing as the primary path (see note above).
+      if (!useStdin) { fallbackArgs.push(CLI.FLAGS.PROMPT, prompt_processed); }
       try {
-        const result = await executeCommand(CLI.COMMANDS.GEMINI, fallbackArgs, onProgress);
+        const result = await executeCommand(CLI.COMMANDS.GEMINI, fallbackArgs, onProgress, useStdin ? prompt_processed : undefined);
         Logger.warn(`Successfully executed with ${MODELS.FLASH} fallback.`);
         await sendStatusMessage(STATUS_MESSAGES.FLASH_SUCCESS);
         return result;


### PR DESCRIPTION
## Summary

Harvests the still-valuable, **already-tested** Windows fixes from #27 (`main-windows-patch`) onto the current security branch, so they land instead of sitting in a long-running branch. Authored here as small, focused changes on top of the CVE-2026-0755 fix.

Stacked on `security/cve-2026-0755` (#76) so it keeps the security fixes and doesn't reintroduce the broken `-p` quoting. GitHub will auto-retarget this to `main` once #76 merges; review/merge #76 first.

## What it does

- **stdin prompt passing** — `changeMode` and `@file` prompts are sent to the Gemini CLI on **stdin** instead of the `-p` flag (`useStdin = changeMode || prompt.includes('@')`). This:
  - sidesteps cmd.exe argument parsing on Windows entirely (the prompt never becomes a shell token), and
  - avoids the OS command-line length limit, which large `@file`/changeMode prompts can exceed.
  - `assertSafeFileReferences()` still runs first, so `@file` containment applies to the stdin path too.
- **`windowsHide`** — suppresses the popup console window when spawning on Windows.
- Simple prompts still use `-p`, passed verbatim (Windows quoting handled by `commandExecutor`'s `quoteForCmd`).

## Provenance

This is the tested approach from #27 — the stdin routing and `windowsHide` were verified there on Windows. Reconciled with the security model (no `\"${prompt}\"` wrapping; containment preserved). #27 will be closed pointing here.

## Test plan

- [x] `npm run build` (tsc) passes.
- [ ] Windows smoke test (was previously verified in #27): changeMode + `@file` prompts via stdin, simple prompt via `-p`, no popup console window.