### PR TITLE
docs: Gemini OAuth (GCA) config + note on Claude Code progress bug (#53617)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,36 @@ If you installed globally, use this configuration instead:
 }
 ```
 
+### Authentication: Google login (OAuth) instead of an API key
+
+This server does not handle authentication itself — it runs the installed Gemini CLI, which owns auth. The Gemini CLI selects an auth method from its environment in this order:
+
+1. `GOOGLE_GENAI_USE_GCA=true` → `oauth-personal` (Google login)
+2. `GOOGLE_GENAI_USE_VERTEXAI=true` → Vertex AI
+3. `GEMINI_API_KEY` → Gemini API key
+
+So setting `GOOGLE_GENAI_USE_GCA=true` makes the Gemini CLI select `oauth-personal` (Google login) ahead of `GEMINI_API_KEY`.
+
+For Claude MCP registrations that should use Google/OAuth rather than an API key, set `HOME`, `GEMINI_CLI_HOME`, and `GOOGLE_GENAI_USE_GCA=true` in the MCP server `env` block. `HOME`/`GEMINI_CLI_HOME` ensure the CLI finds your existing OAuth credentials (`~/.gemini`) when the MCP client launches the server with a reduced environment.
+
+```json
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "npx",
+      "args": ["-y", "gemini-mcp-tool"],
+      "env": {
+        "HOME": "/Users/you",
+        "GEMINI_CLI_HOME": "/Users/you",
+        "GOOGLE_GENAI_USE_GCA": "true"
+      }
+    }
+  }
+}
+```
+
+Replace `/Users/you` with your home directory (the one where you ran `gemini` and completed the Google login). With this set, no `GEMINI_API_KEY` is required.
+
 **Configuration File Locations:**
 
 - **Claude Desktop**:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,35 @@ For Claude Desktop users, add this to your configuration file:
 ::: warning
 You must restart Claude Desktop ***completely*** for changes to take effect.
 :::
+
+## Authentication: Google login (OAuth) instead of an API key
+
+This server runs the installed Gemini CLI, which owns authentication. The Gemini CLI picks an auth method from its environment in this order:
+
+1. `GOOGLE_GENAI_USE_GCA=true` → `oauth-personal` (Google login)
+2. `GOOGLE_GENAI_USE_VERTEXAI=true` → Vertex AI
+3. `GEMINI_API_KEY` → Gemini API key
+
+Setting `GOOGLE_GENAI_USE_GCA=true` therefore makes the Gemini CLI select `oauth-personal` (Google login) ahead of `GEMINI_API_KEY`. For Claude MCP registrations that should use Google/OAuth rather than an API key, set `HOME`, `GEMINI_CLI_HOME`, and `GOOGLE_GENAI_USE_GCA=true` in the MCP server `env` block so the CLI finds your existing OAuth credentials (`~/.gemini`):
+
+```json
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "npx",
+      "args": ["-y", "gemini-mcp-tool"],
+      "env": {
+        "HOME": "/Users/you",
+        "GEMINI_CLI_HOME": "/Users/you",
+        "GOOGLE_GENAI_USE_GCA": "true"
+      }
+    }
+  }
+}
+```
+
+Replace `/Users/you` with the home directory where you ran `gemini` and completed the Google login.
+
 ## Other MCP Clients
 
 Gemini MCP Tool works with 40+ MCP clients! Here are the common configuration patterns:

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -197,6 +197,28 @@ claude mcp list
 /gemini-cli:analyze @specific-function.js explain this function
 ```
 
+## Known Issues
+
+### Claude Code disconnect after a successful call (progress notifications)
+
+On some Claude Code versions, a stdio MCP server can be disconnected after a successful `tools/call` response when the server emits progress notifications. This is tracked upstream in [anthropics/claude-code#53617](https://github.com/anthropics/claude-code/issues/53617).
+
+Progress notifications remain **on by default** (they keep long analyses from timing out). If you hit this disconnect on an affected Claude Code version, you can opt out of progress notifications by setting `GEMINI_MCP_DISABLE_PROGRESS=1` in the MCP server `env` block:
+
+```json
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "npx",
+      "args": ["-y", "gemini-mcp-tool"],
+      "env": {
+        "GEMINI_MCP_DISABLE_PROGRESS": "1"
+      }
+    }
+  }
+}
+```
+
 ## File Analysis Issues
 
 ### "File not found"

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,14 @@ const server = new Server(
   },
 );
 
+// Progress notifications are ON by default. Some Claude Code versions disconnect a
+// stdio MCP server after a successful tools/call response when the server emits
+// progress notifications (anthropics/claude-code#53617). As an opt-out workaround,
+// set GEMINI_MCP_DISABLE_PROGRESS=1 (or =true) to suppress progress notifications.
+const PROGRESS_DISABLED =
+  process.env.GEMINI_MCP_DISABLE_PROGRESS === "1" ||
+  process.env.GEMINI_MCP_DISABLE_PROGRESS === "true";
+
 let isProcessing = false; let currentOperationName = ""; let latestOutput = "";
 
 async function sendNotification(method: string, params: any) {
@@ -170,8 +178,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
   const toolName: string = request.params.name;
 
   if (toolExists(toolName)) {
-    // Check if client requested progress updates
-    const progressToken = (request.params as any)._meta?.progressToken;
+    // Check if client requested progress updates (unless opted out via env var)
+    const progressToken = PROGRESS_DISABLED
+      ? undefined
+      : (request.params as any)._meta?.progressToken;
     
     // Start progress updates if client requested them
     const progressData = startProgressUpdates(toolName, progressToken);


### PR DESCRIPTION
## Summary

Scoped follow-up to #65. Everything else in #65 is intentionally excluded (see below).

### 1. Gemini CLI OAuth (GCA) configuration docs
- Document that setting `GOOGLE_GENAI_USE_GCA=true` makes the Gemini CLI select `oauth-personal` (Google login) **ahead of** `GEMINI_API_KEY`.
- Recommend, for Claude MCP registrations that should use Google/OAuth instead of an API key, setting `HOME`, `GEMINI_CLI_HOME`, and `GOOGLE_GENAI_USE_GCA=true` in the MCP server `env` block (so the CLI finds the existing `~/.gemini` OAuth credentials when launched with a reduced environment).
- Added to `README.md` (Configuration section) and `docs/getting-started.md`.

**Verification:** The auth-selection order was verified against `@google/gemini-cli` source — `packages/core/src/core/contentGenerator.ts`, function `getAuthTypeFromEnv()`, which documents and implements the order:
1. `GOOGLE_GENAI_USE_GCA=true` → `LOGIN_WITH_GOOGLE` (`'oauth-personal'`)
2. `GOOGLE_GENAI_USE_VERTEXAI=true` → Vertex AI
3. `GEMINI_API_KEY` → Gemini API key

### 2. Note on Claude Code progress-notification disconnect (#53617)
- Added a "Known Issues" entry in `docs/resources/troubleshooting.md` referencing [anthropics/claude-code#53617](https://github.com/anthropics/claude-code/issues/53617): *on some Claude Code versions, a stdio MCP server can be disconnected after a successful `tools/call` response when the server emits progress notifications.*
- Added an **opt-out** env var `GEMINI_MCP_DISABLE_PROGRESS` (wired minimally in `src/index.ts`) that suppresses progress notifications when set.
- **Progress notifications stay ON by default.** This is a manual workaround for affected clients only — no opt-in flag, no default change.

## Origin
These two changes originate from #65. This PR is a deliberately narrow follow-up.

## Intentionally excluded from #65 (out of scope here)
- No `@modelcontextprotocol/sdk` or other dependency upgrades; no changes to `zod`, `zod-to-json-schema`, or `src/tools/registry.ts`.
- No new `src/utils/cliExecutor.ts` and no changes to `geminiExecutor.ts` / `commandExecutor.ts` (#65's `spawn` `shell:false` executor would reintroduce the Windows `.cmd` EINVAL bug already fixed on `main`).
- No change to the Node `engines` floor in `package.json`.
- Progress notifications are **not** disabled by default (#65 made them opt-in; this PR keeps the existing default and only adds an opt-out).

## Verification
- `npm run build` passes.

**Draft — do not merge.**

---