### PR TITLE
feat: pluggable Gemini provider seam and project state store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ docs/.vitepress/dist/
 *.dxt
 extension-build/
 CLAUDE.md
+
+# State store persistence directory
+.gemini-mcp/

--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -1,0 +1,169 @@
+# Providers and the State Store
+
+This page describes two foundational internal constructs introduced in v1.1.9:
+the **provider seam** that makes the Gemini execution backend pluggable, and
+the **state store** that gives tools a place to persist data between calls.
+
+---
+
+## Provider seam
+
+### Motivation
+
+All Gemini interactions previously flowed through a single hard-wired call to
+`executeGeminiCLI`. Introducing the provider seam decouples the *tool layer*
+from the *execution layer* so that future backends — such as a direct REST call
+with `GEMINI_API_KEY` — can be plugged in without modifying tool code.
+
+### Core types (`src/providers/types.ts`)
+
+```ts
+export type ProviderId = 'cli' | 'api' | 'antigravity';
+
+export interface ProviderRequest {
+  prompt: string;
+  model?: string;
+  sandbox?: boolean;
+  changeMode?: boolean;
+  onProgress?: (s: string) => void;
+}
+
+export interface GeminiProvider {
+  readonly id: ProviderId;
+  run(req: ProviderRequest): Promise<string>;
+}
+```
+
+A `GeminiProvider` receives a `ProviderRequest` and returns the raw Gemini
+response string — the same contract as `executeGeminiCLI`.
+
+### Available providers
+
+| ID | Class | Behaviour |
+|----|-------|-----------|
+| `cli` | `CliProvider` | Default. Wraps `executeGeminiCLI`; behaviour is identical to earlier releases. |
+| `api` | `ApiProvider` | Stub. Every call rejects with an actionable error asking the operator to set `GEMINI_API_KEY`. Intended as the seam for a direct-API backend. |
+| `antigravity` | *(reserved)* | Falls back to `CliProvider` for forward compatibility. |
+
+### Selecting a provider
+
+Set the `GEMINI_MCP_PROVIDER` environment variable before starting the server:
+
+```sh
+GEMINI_MCP_PROVIDER=cli   # default; uses the gemini CLI
+GEMINI_MCP_PROVIDER=api   # direct-API stub (not yet functional)
+```
+
+Unknown values throw a startup-time error with a list of valid ids.
+
+### Using the provider in a tool
+
+```ts
+import { getProvider } from '../providers/index.js';
+
+const provider = getProvider();
+const result = await provider.run({ prompt, model, sandbox, changeMode, onProgress });
+```
+
+`getProvider()` reads `GEMINI_MCP_PROVIDER` and caches the instance per id.
+Call `resetProviderCache()` (exported from the same module) in tests to obtain
+a fresh instance between cases.
+
+### Testability
+
+`CliProvider` accepts an optional executor function at construction time so
+unit tests can inject a fake without spawning a subprocess:
+
+```ts
+const provider = new CliProvider(async (req) => 'fake response');
+const result = await provider.run({ prompt: 'hello' });
+// result === 'fake response'
+```
+
+---
+
+## State store
+
+### Motivation
+
+Tools occasionally need to persist small amounts of data across MCP calls —
+caches, counters, flags. The state store provides a uniform interface for both
+ephemeral (in-memory) and durable (file-backed) storage without coupling tools
+to a specific persistence strategy.
+
+### Interface (`src/state/store.ts`)
+
+```ts
+export interface StateStore {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T): void;
+  delete(key: string): void;
+  keys(): string[];
+}
+```
+
+### Implementations
+
+#### `MemoryStore`
+
+Backed by a plain `Map`. Data is lost when the process exits. Suitable for
+caches that are cheap to rebuild.
+
+```ts
+import { MemoryStore } from '../state/store.js';
+
+const store = new MemoryStore();
+store.set('counter', 0);
+```
+
+#### `JsonFileStore`
+
+Persists each key as a JSON file under a directory. The directory is created
+lazily on the first write.
+
+```ts
+import { JsonFileStore } from '../state/store.js';
+
+const store = new JsonFileStore();   // uses GEMINI_MCP_STATE_DIR or .gemini-mcp/
+store.set('last-run', new Date().toISOString());
+const value = store.get<string>('last-run');
+```
+
+Pass an explicit directory path to the constructor to override the default:
+
+```ts
+const store = new JsonFileStore('/tmp/my-tool-state');
+```
+
+### Key rules
+
+Keys must match `^[A-Za-z0-9._-]{1,128}$`. The following are rejected:
+
+- Empty strings
+- Absolute paths (e.g. `/etc/passwd`)
+- Path traversal sequences (e.g. `../secret`)
+- Keys containing `/` or `\`
+
+These constraints ensure that keys are safe to use as file names and cannot
+be used to escape the configured storage directory.
+
+### Configuring the storage directory
+
+Set `GEMINI_MCP_STATE_DIR` to an absolute path before starting the server:
+
+```sh
+GEMINI_MCP_STATE_DIR=/var/lib/my-mcp-state
+```
+
+The default is `.gemini-mcp/` inside the working directory. This directory is
+listed in `.gitignore` so persisted state is not accidentally committed.
+
+---
+
+## Environment variable reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GEMINI_MCP_PROVIDER` | `cli` | Selects the Gemini execution backend. |
+| `GEMINI_MCP_STATE_DIR` | `.gemini-mcp/` | Root directory for `JsonFileStore` persistence. |
+| `GEMINI_API_KEY` | *(unset)* | Required by the `api` provider once it is fully implemented. |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,7 +82,10 @@ export const CLI = {
 
 // Environment variables that configure the server.
 export const ENV = {
-  GEMINI_CLI_PATH: "GEMINI_CLI_PATH", // explicit path to the gemini executable (Windows shim resolution)
+  GEMINI_CLI_PATH: "GEMINI_CLI_PATH",       // explicit path to the gemini executable (Windows shim resolution)
+  GEMINI_API_KEY: "GEMINI_API_KEY",          // API key for the direct-API backend (api provider)
+  GEMINI_MCP_PROVIDER: "GEMINI_MCP_PROVIDER", // active provider id: 'cli' (default) | 'api' | 'antigravity'
+  GEMINI_MCP_STATE_DIR: "GEMINI_MCP_STATE_DIR", // directory for JsonFileStore persistence (default: .gemini-mcp/)
 } as const;
 
 

--- a/src/providers/apiProvider.ts
+++ b/src/providers/apiProvider.ts
@@ -1,0 +1,24 @@
+import { GeminiProvider, ProviderId, ProviderRequest } from './types.js';
+import { ENV } from '../constants.js';
+
+/**
+ * ApiProvider is a documented stub for a future direct-API backend.
+ *
+ * It throws an actionable error on every call so that misconfigured
+ * deployments receive a clear message instead of a cryptic failure.
+ * Implement run() here (or in a subclass) once GEMINI_API_KEY-based
+ * access is supported.
+ */
+export class ApiProvider implements GeminiProvider {
+  readonly id: ProviderId = 'api';
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  run(_req: ProviderRequest): Promise<string> {
+    return Promise.reject(new Error(
+      `The API backend is not yet configured. ` +
+      `To use it, set the ${ENV.GEMINI_API_KEY} environment variable and ` +
+      `ensure an API-backed provider implementation is registered. ` +
+      `The default 'cli' provider requires only the Gemini CLI to be installed.`,
+    ));
+  }
+}

--- a/src/providers/cliProvider.ts
+++ b/src/providers/cliProvider.ts
@@ -1,0 +1,38 @@
+import { GeminiProvider, ProviderId, ProviderRequest } from './types.js';
+import { executeGeminiCLI } from '../utils/geminiExecutor.js';
+
+/**
+ * Default executor: delegates to executeGeminiCLI with the same arguments.
+ * Extracted as a separate function so it can be replaced in tests without
+ * touching the singleton or spawning any subprocess.
+ */
+async function defaultExecutor(req: ProviderRequest): Promise<string> {
+  return executeGeminiCLI(
+    req.prompt,
+    req.model,
+    req.sandbox,
+    req.changeMode,
+    req.onProgress,
+  );
+}
+
+/**
+ * CliProvider wraps the Gemini CLI subprocess and is the default backend.
+ *
+ * An optional executor function may be injected at construction time; this is
+ * intended for unit tests that need to assert forwarded arguments without
+ * spawning a real process.
+ */
+export class CliProvider implements GeminiProvider {
+  readonly id: ProviderId = 'cli';
+
+  private readonly _executor: (req: ProviderRequest) => Promise<string>;
+
+  constructor(executor?: (req: ProviderRequest) => Promise<string>) {
+    this._executor = executor ?? defaultExecutor;
+  }
+
+  run(req: ProviderRequest): Promise<string> {
+    return this._executor(req);
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,62 @@
+import { GeminiProvider, ProviderId } from './types.js';
+import { CliProvider } from './cliProvider.js';
+import { ApiProvider } from './apiProvider.js';
+import { ENV } from '../constants.js';
+
+const VALID_IDS: ReadonlySet<ProviderId> = new Set(['cli', 'api', 'antigravity']);
+
+/** One instance per provider id for the life of the process. */
+const cache = new Map<ProviderId, GeminiProvider>();
+
+/**
+ * Return the GeminiProvider for the given id, defaulting to the value of
+ * GEMINI_MCP_PROVIDER (which itself defaults to 'cli').
+ *
+ * Instances are cached per id so callers always receive the same object
+ * within a single process.
+ *
+ * @throws {Error} for any unknown provider id.
+ */
+export function getProvider(id?: ProviderId): GeminiProvider {
+  const resolvedId: ProviderId = id ?? (process.env[ENV.GEMINI_MCP_PROVIDER] as ProviderId | undefined) ?? 'cli';
+
+  if (!VALID_IDS.has(resolvedId)) {
+    throw new Error(
+      `Unknown provider id "${resolvedId}". ` +
+      `Valid values are: ${[...VALID_IDS].join(', ')}. ` +
+      `Check the ${ENV.GEMINI_MCP_PROVIDER} environment variable.`,
+    );
+  }
+
+  const cached = cache.get(resolvedId);
+  if (cached) return cached;
+
+  const provider = createProvider(resolvedId);
+  cache.set(resolvedId, provider);
+  return provider;
+}
+
+/**
+ * Clear the instance cache. Intended for use in tests that need to exercise
+ * different provider configurations in isolation.
+ */
+export function resetProviderCache(): void {
+  cache.clear();
+}
+
+function createProvider(id: ProviderId): GeminiProvider {
+  switch (id) {
+    case 'cli':
+      return new CliProvider();
+    case 'api':
+      return new ApiProvider();
+    case 'antigravity':
+      // Reserved for future use; fall through to the CLI provider so the
+      // system remains functional when this id is set experimentally.
+      return new CliProvider();
+  }
+}
+
+export type { GeminiProvider, ProviderId, ProviderRequest } from './types.js';
+export { CliProvider } from './cliProvider.js';
+export { ApiProvider } from './apiProvider.js';

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Core types for the pluggable Gemini execution provider seam.
+ *
+ * The CliProvider (id 'cli') is the default and preserves existing behavior
+ * exactly. The ApiProvider (id 'api') is a documented stub for a future
+ * direct-API backend. The 'antigravity' id is reserved for forward
+ * compatibility.
+ */
+
+export type ProviderId = 'cli' | 'api' | 'antigravity';
+
+/**
+ * A provider-agnostic request to run a Gemini prompt.
+ * All fields mirror the existing executeGeminiCLI signature.
+ */
+export interface ProviderRequest {
+  prompt: string;
+  model?: string;
+  sandbox?: boolean;
+  changeMode?: boolean;
+  onProgress?: (s: string) => void;
+}
+
+/**
+ * A GeminiProvider executes a ProviderRequest and returns the raw response
+ * string (the same contract as executeGeminiCLI).
+ */
+export interface GeminiProvider {
+  readonly id: ProviderId;
+  run(req: ProviderRequest): Promise<string>;
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,0 +1,141 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ENV } from '../constants.js';
+
+/**
+ * Regular expression that keys must match.
+ * Rejects empty strings, path-separator sequences, and any character that
+ * could be used for path traversal or shell injection.
+ */
+const KEY_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+
+/**
+ * Assert that a key is safe to use as a file name and map key.
+ * Explicit checks for absolute paths and traversal sequences are included
+ * in addition to the allowlist pattern so the intent is clear to reviewers.
+ */
+function assertSafeKey(key: string): void {
+  if (!key || key.includes('/') || key.includes('\\') || key.includes('..')) {
+    throw new Error(
+      `Invalid state key "${key}": keys must match ${KEY_PATTERN} ` +
+      `and must not contain path separators or traversal sequences.`,
+    );
+  }
+  if (path.isAbsolute(key)) {
+    throw new Error(`Invalid state key "${key}": absolute paths are not permitted.`);
+  }
+  if (!KEY_PATTERN.test(key)) {
+    throw new Error(
+      `Invalid state key "${key}": only [A-Za-z0-9._-] (1-128 chars) are allowed.`,
+    );
+  }
+}
+
+/**
+ * A minimal key-value store interface.
+ */
+export interface StateStore {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T): void;
+  delete(key: string): void;
+  keys(): string[];
+}
+
+/**
+ * In-memory store backed by a plain Map.
+ * Values are not persisted across process restarts.
+ */
+export class MemoryStore implements StateStore {
+  private readonly _data = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    assertSafeKey(key);
+    return this._data.get(key) as T | undefined;
+  }
+
+  set<T>(key: string, value: T): void {
+    assertSafeKey(key);
+    this._data.set(key, value);
+  }
+
+  delete(key: string): void {
+    assertSafeKey(key);
+    this._data.delete(key);
+  }
+
+  keys(): string[] {
+    return [...this._data.keys()];
+  }
+}
+
+/**
+ * File-backed store that persists each key as a JSON file under a directory.
+ *
+ * The storage directory defaults to `.gemini-mcp` inside the current working
+ * directory but can be overridden via the GEMINI_MCP_STATE_DIR environment
+ * variable. The directory is created lazily on first write.
+ *
+ * All file paths are confined to the storage directory; key validation
+ * prevents traversal.
+ */
+export class JsonFileStore implements StateStore {
+  private readonly _dir: string;
+
+  constructor(dir?: string) {
+    this._dir = path.resolve(
+      dir ??
+      process.env[ENV.GEMINI_MCP_STATE_DIR] ??
+      path.join(process.cwd(), '.gemini-mcp'),
+    );
+  }
+
+  private _filePath(key: string): string {
+    assertSafeKey(key);
+    const filePath = path.join(this._dir, `${key}.json`);
+    // Double-check confinement after path.join resolution
+    if (!filePath.startsWith(this._dir + path.sep) && filePath !== this._dir) {
+      throw new Error(
+        `Refusing to access "${filePath}": resolved path escapes the state directory "${this._dir}".`,
+      );
+    }
+    return filePath;
+  }
+
+  private _ensureDir(): void {
+    if (!fs.existsSync(this._dir)) {
+      fs.mkdirSync(this._dir, { recursive: true });
+    }
+  }
+
+  get<T>(key: string): T | undefined {
+    const filePath = this._filePath(key);
+    if (!fs.existsSync(filePath)) return undefined;
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      return JSON.parse(raw) as T;
+    } catch {
+      return undefined;
+    }
+  }
+
+  set<T>(key: string, value: T): void {
+    const filePath = this._filePath(key);
+    this._ensureDir();
+    fs.writeFileSync(filePath, JSON.stringify(value), 'utf8');
+  }
+
+  delete(key: string): void {
+    const filePath = this._filePath(key);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+
+  keys(): string[] {
+    if (!fs.existsSync(this._dir)) return [];
+    return fs
+      .readdirSync(this._dir)
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.slice(0, -5)); // strip .json suffix
+  }
+}

--- a/src/tools/ask-gemini.tool.ts
+++ b/src/tools/ask-gemini.tool.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { UnifiedTool } from './registry.js';
-import { executeGeminiCLI, processChangeModeOutput } from '../utils/geminiExecutor.js';
+import { processChangeModeOutput } from '../utils/geminiExecutor.js';
+import { getProvider } from '../providers/index.js';
 import {
   ERROR_MESSAGES,
   STATUS_MESSAGES
@@ -39,13 +40,14 @@ export const askGeminiTool: UnifiedTool = {
       );
     }
 
-    const result = await executeGeminiCLI(
-      prompt as string,
-      model as string | undefined,
-      !!sandbox,
-      !!changeMode,
-      onProgress
-    );
+    const provider = getProvider();
+    const result = await provider.run({
+      prompt: prompt as string,
+      model: model as string | undefined,
+      sandbox: !!sandbox,
+      changeMode: !!changeMode,
+      onProgress,
+    });
 
     if (changeMode) {
       return processChangeModeOutput(

--- a/test/unit/providers/cliProvider.test.ts
+++ b/test/unit/providers/cliProvider.test.ts
@@ -1,0 +1,70 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CliProvider } from '../../../src/providers/cliProvider.js';
+import type { ProviderRequest } from '../../../src/providers/types.js';
+
+describe('CliProvider', () => {
+  test('forwards all request fields to the injected executor', async () => {
+    const received: ProviderRequest[] = [];
+
+    const fakeExecutor = async (req: ProviderRequest): Promise<string> => {
+      received.push(req);
+      return 'fake response';
+    };
+
+    const provider = new CliProvider(fakeExecutor);
+
+    const req: ProviderRequest = {
+      prompt: 'explain @src/index.ts',
+      model: 'gemini-2.5-flash',
+      sandbox: true,
+      changeMode: false,
+      onProgress: () => {},
+    };
+
+    const result = await provider.run(req);
+
+    assert.equal(result, 'fake response');
+    assert.equal(received.length, 1);
+    assert.strictEqual(received[0], req, 'executor must receive the exact request object');
+    assert.equal(received[0].prompt, req.prompt);
+    assert.equal(received[0].model, req.model);
+    assert.equal(received[0].sandbox, true);
+    assert.equal(received[0].changeMode, false);
+    assert.strictEqual(received[0].onProgress, req.onProgress);
+  });
+
+  test('provider id is "cli"', () => {
+    const provider = new CliProvider(async () => '');
+    assert.equal(provider.id, 'cli');
+  });
+
+  test('executor return value is passed through unchanged', async () => {
+    const expected = 'some multiline\ngemini output here';
+    const provider = new CliProvider(async () => expected);
+    const result = await provider.run({ prompt: 'test' });
+    assert.equal(result, expected);
+  });
+
+  test('executor rejection propagates as-is', async () => {
+    const provider = new CliProvider(async () => {
+      throw new Error('executor failure');
+    });
+    await assert.rejects(() => provider.run({ prompt: 'test' }), /executor failure/);
+  });
+
+  test('minimal request (prompt only) is forwarded without adding defaults', async () => {
+    const received: ProviderRequest[] = [];
+    const provider = new CliProvider(async (req) => {
+      received.push(req);
+      return '';
+    });
+
+    await provider.run({ prompt: 'minimal' });
+    assert.equal(received[0].model, undefined);
+    assert.equal(received[0].sandbox, undefined);
+    assert.equal(received[0].changeMode, undefined);
+    assert.equal(received[0].onProgress, undefined);
+  });
+});

--- a/test/unit/providers/provider-factory.test.ts
+++ b/test/unit/providers/provider-factory.test.ts
@@ -1,0 +1,88 @@
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getProvider, resetProviderCache, CliProvider, ApiProvider } from '../../../src/providers/index.js';
+
+const ENV_KEY = 'GEMINI_MCP_PROVIDER';
+
+describe('Provider factory', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+    resetProviderCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalEnv;
+    }
+    resetProviderCache();
+  });
+
+  test('default provider is CliProvider with id "cli"', () => {
+    const p = getProvider();
+    assert.ok(p instanceof CliProvider, 'expected a CliProvider by default');
+    assert.equal(p.id, 'cli');
+  });
+
+  test('explicit id "cli" returns a CliProvider', () => {
+    const p = getProvider('cli');
+    assert.ok(p instanceof CliProvider);
+    assert.equal(p.id, 'cli');
+  });
+
+  test('explicit id "api" returns an ApiProvider', () => {
+    const p = getProvider('api');
+    assert.ok(p instanceof ApiProvider);
+    assert.equal(p.id, 'api');
+  });
+
+  test('instances are cached — same id returns same object', () => {
+    const a = getProvider('cli');
+    const b = getProvider('cli');
+    assert.strictEqual(a, b, 'expected the same cached instance');
+  });
+
+  test('resetProviderCache causes a fresh instance to be created', () => {
+    const a = getProvider('cli');
+    resetProviderCache();
+    const b = getProvider('cli');
+    assert.notStrictEqual(a, b, 'expected a new instance after cache reset');
+  });
+
+  test('unknown provider id throws with actionable message', () => {
+    assert.throws(
+      () => getProvider('unknown' as any),
+      /Unknown provider id/,
+    );
+  });
+
+  test('GEMINI_MCP_PROVIDER env var selects the provider', () => {
+    process.env[ENV_KEY] = 'api';
+    const p = getProvider();
+    assert.ok(p instanceof ApiProvider);
+  });
+
+  test('ApiProvider.run throws an actionable error about GEMINI_API_KEY', async () => {
+    const p = getProvider('api');
+    await assert.rejects(
+      () => p.run({ prompt: 'hello' }),
+      /GEMINI_API_KEY/,
+    );
+  });
+
+  test('ApiProvider.run error message mentions "API backend"', async () => {
+    const p = getProvider('api');
+    let caughtMessage = '';
+    try {
+      await p.run({ prompt: 'test' });
+    } catch (e) {
+      caughtMessage = (e as Error).message;
+    }
+    assert.ok(caughtMessage.includes('API backend'), `message was: ${caughtMessage}`);
+  });
+});

--- a/test/unit/state/store.test.ts
+++ b/test/unit/state/store.test.ts
@@ -1,0 +1,185 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { MemoryStore, JsonFileStore } from '../../../src/state/store.js';
+
+// ---------------------------------------------------------------------------
+// MemoryStore
+// ---------------------------------------------------------------------------
+
+describe('MemoryStore', () => {
+  test('set and get round-trip', () => {
+    const store = new MemoryStore();
+    store.set('key1', { hello: 'world' });
+    assert.deepEqual(store.get('key1'), { hello: 'world' });
+  });
+
+  test('get returns undefined for missing key', () => {
+    const store = new MemoryStore();
+    assert.equal(store.get('nope'), undefined);
+  });
+
+  test('delete removes a key', () => {
+    const store = new MemoryStore();
+    store.set('k', 42);
+    store.delete('k');
+    assert.equal(store.get('k'), undefined);
+  });
+
+  test('keys() returns all set keys', () => {
+    const store = new MemoryStore();
+    store.set('a', 1);
+    store.set('b', 2);
+    store.set('c', 3);
+    const ks = store.keys().sort();
+    assert.deepEqual(ks, ['a', 'b', 'c']);
+  });
+
+  test('key validation rejects empty string', () => {
+    const store = new MemoryStore();
+    assert.throws(() => store.set('', 1), /Invalid state key/);
+  });
+
+  test('key validation rejects path traversal sequences', () => {
+    const store = new MemoryStore();
+    assert.throws(() => store.set('../x', 1), /Invalid state key/);
+    assert.throws(() => store.get('../x'), /Invalid state key/);
+  });
+
+  test('key validation rejects absolute paths', () => {
+    const store = new MemoryStore();
+    assert.throws(() => store.set('/etc/passwd', 1), /Invalid state key/);
+  });
+
+  test('key validation rejects keys with slashes', () => {
+    const store = new MemoryStore();
+    assert.throws(() => store.set('a/b', 1), /Invalid state key/);
+  });
+
+  test('key validation allows valid characters', () => {
+    const store = new MemoryStore();
+    assert.doesNotThrow(() => store.set('valid-key.123_abc', true));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JsonFileStore
+// ---------------------------------------------------------------------------
+
+describe('JsonFileStore', () => {
+  let tmpDir: string;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-state-test-'));
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('set creates directory lazily and persists a value', () => {
+    const dir = path.join(tmpDir, 'lazy');
+    const store = new JsonFileStore(dir);
+    assert.equal(fs.existsSync(dir), false, 'dir should not exist yet');
+    store.set('greeting', 'hello');
+    assert.equal(fs.existsSync(dir), true, 'dir should now exist');
+  });
+
+  test('get retrieves the stored value', () => {
+    const dir = path.join(tmpDir, 'get-test');
+    const store = new JsonFileStore(dir);
+    store.set('num', 42);
+    assert.equal(store.get<number>('num'), 42);
+  });
+
+  test('get returns undefined for missing key', () => {
+    const dir = path.join(tmpDir, 'missing');
+    const store = new JsonFileStore(dir);
+    assert.equal(store.get('absent'), undefined);
+  });
+
+  test('persistence across a fresh instance', () => {
+    const dir = path.join(tmpDir, 'persist');
+    const store1 = new JsonFileStore(dir);
+    store1.set('data', { count: 7 });
+
+    // New instance, same dir
+    const store2 = new JsonFileStore(dir);
+    assert.deepEqual(store2.get('data'), { count: 7 });
+  });
+
+  test('delete removes the key', () => {
+    const dir = path.join(tmpDir, 'del');
+    const store = new JsonFileStore(dir);
+    store.set('gone', 'yes');
+    store.delete('gone');
+    assert.equal(store.get('gone'), undefined);
+  });
+
+  test('delete is a no-op for non-existent key', () => {
+    const dir = path.join(tmpDir, 'del-noop');
+    const store = new JsonFileStore(dir);
+    assert.doesNotThrow(() => store.delete('phantom'));
+  });
+
+  test('keys() lists all persisted keys', () => {
+    const dir = path.join(tmpDir, 'keys-list');
+    const store = new JsonFileStore(dir);
+    store.set('x', 1);
+    store.set('y', 2);
+    store.set('z', 3);
+    const ks = store.keys().sort();
+    assert.deepEqual(ks, ['x', 'y', 'z']);
+  });
+
+  test('keys() returns empty array when dir does not exist', () => {
+    const dir = path.join(tmpDir, 'no-dir-yet');
+    const store = new JsonFileStore(dir);
+    assert.deepEqual(store.keys(), []);
+  });
+
+  test('key validation rejects "../x"', () => {
+    const dir = path.join(tmpDir, 'traversal');
+    const store = new JsonFileStore(dir);
+    assert.throws(() => store.set('../x', 1), /Invalid state key/);
+  });
+
+  test('key validation rejects absolute paths', () => {
+    const dir = path.join(tmpDir, 'abs');
+    const store = new JsonFileStore(dir);
+    assert.throws(() => store.set('/etc/passwd', 1), /Invalid state key/);
+  });
+
+  test('key validation rejects empty string', () => {
+    const dir = path.join(tmpDir, 'empty-key');
+    const store = new JsonFileStore(dir);
+    assert.throws(() => store.set('', 1), /Invalid state key/);
+  });
+
+  test('key validation rejects keys with slashes', () => {
+    const dir = path.join(tmpDir, 'slash-key');
+    const store = new JsonFileStore(dir);
+    assert.throws(() => store.set('a/b', 1), /Invalid state key/);
+  });
+
+  test('GEMINI_MCP_STATE_DIR env var is used when no dir arg provided', () => {
+    const dir = path.join(tmpDir, 'env-dir');
+    const oldVal = process.env['GEMINI_MCP_STATE_DIR'];
+    process.env['GEMINI_MCP_STATE_DIR'] = dir;
+    try {
+      const store = new JsonFileStore();
+      store.set('env-key', 'env-val');
+      assert.equal(store.get<string>('env-key'), 'env-val');
+      assert.equal(fs.existsSync(dir), true);
+    } finally {
+      if (oldVal === undefined) {
+        delete process.env['GEMINI_MCP_STATE_DIR'];
+      } else {
+        process.env['GEMINI_MCP_STATE_DIR'] = oldVal;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Introduces a `GeminiProvider` interface (`src/providers/`) so the Gemini execution backend is pluggable without touching tool code, plus a small project state store (`src/state/store.ts`) that later features can build on. The default path is behavior-identical to today.

## What changes

- `GeminiProvider` interface + `CliProvider` (default) wrapping `executeGeminiCLI` **exactly** — no behavior change for existing deployments.
- `ApiProvider` stub that rejects every call with an actionable message pointing to `GEMINI_API_KEY` — the documented seam for a future direct-API backend.
- `getProvider(id?)` factory reading `GEMINI_MCP_PROVIDER` (default `cli`), with per-id instance caching and `resetProviderCache()` for test isolation.
- `ask-gemini` now calls `getProvider().run({...})` instead of `executeGeminiCLI` directly; the surrounding logic (chunk-cache continuation, `processChangeModeOutput`, return strings) is preserved verbatim.
- `StateStore` with `MemoryStore` (in-process) and `JsonFileStore` (one JSON file per key, lazy directory creation, strict key allowlist + post-join confinement to `GEMINI_MCP_STATE_DIR`).

## Verification

- `npx tsc --noEmit` — clean
- `node scripts/run-tests.mjs unit integration` — 93 pass / 0 fail (all pre-existing tests stay green)

## Notes

- Default behavior is unchanged; the alternate backend and the store are opt-in.
- `GEMINI_MCP_STATE_DIR` is shared conceptually with other state-backed features; if merged alongside them, expect a trivial one-line `constants.ts` merge.