### PR TITLE
feat: warm repo residency with incremental git-delta analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.log
 .env
 .DS_Store
+.gemini-mcp/
 *.swp
 *.swo
 .vscode/

--- a/docs/concepts/warm-residency.md
+++ b/docs/concepts/warm-residency.md
@@ -1,0 +1,99 @@
+# Warm Repo Residency
+
+## Overview
+
+The `warm-analyze` tool implements *warm repo residency*: rather than shipping
+the entire repository to Gemini on every call, it tracks a **baseline** commit
+SHA and, on follow-up calls, sends only the incremental `git diff` since that
+baseline.
+
+This pattern is well-suited to iterative review sessions—think code-review
+rounds, refactoring feedback loops, or CI-integrated quality gates—where
+re-sending the full workspace on every call wastes both tokens and time.
+
+---
+
+## How it works
+
+### 1. Baseline pass (first call or `reset: true`)
+
+When no baseline is stored, or when `reset: true` is supplied, `warm-analyze`:
+
+1. Records the current `HEAD` SHA as the baseline in `.gemini-mcp/residency.json`.
+2. Runs Gemini over the full workspace using the supplied prompt (identical to
+   `ask-gemini` behaviour).
+3. Returns the analysis with a note confirming the baseline was recorded.
+
+### 2. Delta pass (subsequent calls)
+
+On subsequent calls `warm-analyze`:
+
+1. Reads the stored baseline SHA.
+2. Checks whether that ref is still reachable in the local history.
+3. Runs `git diff <base>..HEAD` and `git status --porcelain` to identify
+   changed files and produce a unified diff.
+4. Applies the **mode decision** (see below).
+
+#### Mode decision
+
+| Condition | Mode |
+|---|---|
+| No baseline stored | `full` |
+| Baseline ref not reachable | `full` |
+| Diff size exceeds `GEMINI_MCP_MAX_DELTA_BYTES` | `full` |
+| Otherwise | `delta` |
+
+- **`delta` mode** — builds a focused prompt containing only the changed-file
+  list and the unified diff, appends the user's question, and calls Gemini.
+- **`full` mode** — falls back to full-workspace analysis, updates the
+  baseline, and notes the reason in the response.
+
+---
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `GEMINI_MCP_STATE_DIR` | `.gemini-mcp` | Directory (relative to project root) where `residency.json` is stored. |
+| `GEMINI_MCP_MAX_DELTA_BYTES` | `200000` | Maximum diff size in bytes before falling back to full-workspace mode. |
+
+Both variables are resolved relative to `process.cwd()` and are confined to
+the project root—values that escape the root are rejected.
+
+---
+
+## Storage format
+
+`<GEMINI_MCP_STATE_DIR>/residency.json` contains:
+
+```json
+{
+  "baseSha": "abc123...",
+  "createdAt": "2026-06-05T10:00:00.000Z"
+}
+```
+
+The file is created lazily on the first `setBaseline` call. Add
+`<GEMINI_MCP_STATE_DIR>/` (default `.gemini-mcp/`) to `.gitignore` to avoid
+committing session state.
+
+---
+
+## Tool parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | `string` | Yes | Analysis question or review request. |
+| `reset` | `boolean` | No | Force a new baseline pass even if one exists. |
+| `model` | `string` | No | Override the Gemini model (e.g. `gemini-2.5-flash`). |
+
+---
+
+## Security notes
+
+- All path resolution is anchored at `process.cwd()`.  A `GEMINI_MCP_STATE_DIR`
+  value that resolves outside the project root is rejected with an error.
+- Git commands are executed via `spawnSync` with `shell: false`; no shell
+  string is constructed from user input.
+- `@file` references in prompts still pass through the existing
+  `assertSafeFileReferences` check in the Gemini executor.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -85,6 +85,13 @@ export const ENV = {
   GEMINI_CLI_PATH: "GEMINI_CLI_PATH", // explicit path to the gemini executable (Windows shim resolution)
 } as const;
 
+// Warm residency: directory for persisting session state (residency.json).
+// Resolved relative to process.cwd(); must remain inside the project root.
+export const GEMINI_MCP_STATE_DIR = "GEMINI_MCP_STATE_DIR" as const;
+
+// Warm residency: maximum diff size (bytes) before falling back to full-workspace analysis.
+export const GEMINI_MCP_MAX_DELTA_BYTES = "GEMINI_MCP_MAX_DELTA_BYTES" as const;
+
 
 // (merged PromptArguments and ToolArguments)
 export interface ToolArguments {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,13 +5,15 @@ import { pingTool, helpTool } from './simple-tools.js';
 import { brainstormTool } from './brainstorm.tool.js';
 import { fetchChunkTool } from './fetch-chunk.tool.js';
 import { timeoutTestTool } from './timeout-test.tool.js';
+import { warmAnalyzeTool } from './warm-analyze.tool.js';
 
 toolRegistry.push(
   askGeminiTool,
   pingTool,
   helpTool,
   brainstormTool,
-  fetchChunkTool
+  fetchChunkTool,
+  warmAnalyzeTool
 );
 
 // Only register test-only tools when explicitly enabled (e.g. judge/e2e test suite)

--- a/src/tools/warm-analyze.tool.ts
+++ b/src/tools/warm-analyze.tool.ts
@@ -1,0 +1,249 @@
+/**
+ * warm-analyze.tool.ts
+ *
+ * The `warm-analyze` tool tracks a baseline repository snapshot and, on
+ * subsequent calls, sends only the incremental git diff instead of shipping the
+ * entire workspace to Gemini.  This dramatically reduces token usage and
+ * latency for iterative review sessions.
+ *
+ * Behaviour:
+ *   - No baseline / reset flag  → record the current HEAD as the baseline, then
+ *     run Gemini over the full workspace (same as ask-gemini).
+ *   - Baseline exists + delta fits in budget  → embed the diff in the prompt and
+ *     run Gemini with that focused context ("delta" mode).
+ *   - Baseline exists but delta is too large or base ref unreachable  → fall back
+ *     to full-workspace mode, note it in the response, and update the baseline.
+ */
+import { z } from "zod";
+import { spawnSync } from "child_process";
+import { UnifiedTool } from "./registry.js";
+import { executeGeminiCLI } from "../utils/geminiExecutor.js";
+import { computeDelta, decideMode, makeDefaultGitRunner } from "../utils/repoDelta.js";
+import { getBaseline, setBaseline } from "../utils/residencyState.js";
+import { Logger } from "../utils/logger.js";
+import { GEMINI_MCP_MAX_DELTA_BYTES } from "../constants.js";
+import { STATUS_MESSAGES } from "../constants.js";
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+const warmAnalyzeArgsSchema = z.object({
+  prompt: z
+    .string()
+    .min(1)
+    .describe(
+      "Question or analysis request. On delta passes this is applied to the changed files only."
+    ),
+  reset: z
+    .boolean()
+    .optional()
+    .describe(
+      "Force a baseline reset: treat this call as the initial full-workspace analysis and record a new baseline."
+    ),
+  model: z
+    .string()
+    .optional()
+    .describe(
+      "Optional Gemini model to use (e.g. 'gemini-2.5-flash'). Defaults to gemini-2.5-pro."
+    ),
+});
+
+// ─── Helper: resolve current HEAD safely ─────────────────────────────────────
+
+function resolveHead(): string | null {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    shell: false,
+  });
+  if (result.status !== 0 || result.error) return null;
+  return (result.stdout ?? "").trim() || null;
+}
+
+/** Returns true when `ref` names a commit reachable in the local history. */
+function isRefReachable(ref: string): boolean {
+  const result = spawnSync("git", ["cat-file", "-e", `${ref}^{commit}`], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    shell: false,
+  });
+  return result.status === 0 && !result.error;
+}
+
+/** Read the configured max-delta budget (env override or 200 000 bytes). */
+function maxDeltaBytes(): number {
+  const raw = process.env[GEMINI_MCP_MAX_DELTA_BYTES];
+  if (raw) {
+    const n = parseInt(raw, 10);
+    if (!isNaN(n) && n > 0) return n;
+  }
+  return 200_000;
+}
+
+// ─── Prompt builders ─────────────────────────────────────────────────────────
+
+export function buildDeltaPrompt(opts: {
+  userPrompt: string;
+  baseRef: string;
+  headRef: string;
+  changedFiles: string[];
+  diff: string;
+  truncated: boolean;
+}): string {
+  const { userPrompt, baseRef, headRef, changedFiles, diff, truncated } = opts;
+
+  const fileList =
+    changedFiles.length > 0
+      ? changedFiles.map((f) => `  - ${f}`).join("\n")
+      : "  (no committed file changes; working-tree modifications may apply)";
+
+  const truncationNote = truncated
+    ? "\n> **Note:** The diff was truncated at the configured byte limit. Some changes may not be shown."
+    : "";
+
+  return `# Incremental Analysis (warm-residency delta pass)
+
+## Changed files since baseline (\`${baseRef.slice(0, 8)}\` → \`${headRef.slice(0, 8)}\`)
+${fileList}
+${truncationNote}
+
+## Git diff
+\`\`\`diff
+${diff}
+\`\`\`
+
+## User request
+${userPrompt}`;
+}
+
+// ─── Tool definition ──────────────────────────────────────────────────────────
+
+export const warmAnalyzeTool: UnifiedTool = {
+  name: "warm-analyze",
+  description:
+    "Incremental repository analysis using git-delta warm residency. " +
+    "The first call (or any call with reset:true) records a baseline and runs a " +
+    "full-workspace analysis. Subsequent calls send only the diff since the " +
+    "baseline, dramatically reducing token usage for iterative review sessions.",
+  zodSchema: warmAnalyzeArgsSchema,
+  prompt: {
+    description:
+      "Analyse repository changes incrementally using warm residency. Sends a full " +
+      "workspace on the first call and only the git diff on follow-up calls.",
+  },
+  category: "gemini",
+
+  execute: async (args, onProgress) => {
+    const { prompt, reset, model } = args;
+
+    if (!prompt?.trim()) {
+      throw new Error(
+        "Please provide a prompt for analysis. Use warm-analyze with a question about the codebase."
+      );
+    }
+
+    const currentHead = resolveHead();
+    if (!currentHead) {
+      return "❌ warm-analyze requires a git repository. No HEAD commit was found in the working directory.";
+    }
+
+    const maxBytes = maxDeltaBytes();
+
+    // ── Decide whether to run a baseline (full) pass or a delta pass ──────────
+
+    const stored = getBaseline();
+    const forceReset = !!reset;
+
+    if (!stored || forceReset) {
+      // ── Baseline pass ─────────────────────────────────────────────────────
+      Logger.debug(
+        `warm-analyze: ${forceReset ? "reset requested" : "no baseline"} → baseline pass`
+      );
+      setBaseline(currentHead);
+
+      const note = forceReset
+        ? "\n\n> **warm-analyze:** Baseline reset. This is a full-workspace analysis; subsequent calls will use incremental diffs."
+        : "\n\n> **warm-analyze:** Initial baseline recorded. Subsequent calls will use incremental diffs.";
+
+      onProgress?.(STATUS_MESSAGES.PROCESSING_START);
+      const result = await executeGeminiCLI(
+        prompt as string,
+        model as string | undefined,
+        false,
+        false,
+        onProgress
+      );
+      return `${STATUS_MESSAGES.GEMINI_RESPONSE}\n${result}${note}`;
+    }
+
+    // ── Delta pass ────────────────────────────────────────────────────────────
+    const { baseSha } = stored;
+    const baseReachable = isRefReachable(baseSha);
+
+    let mode: "delta" | "full";
+    let deltaResult: ReturnType<typeof computeDelta> | null = null;
+
+    if (!baseReachable) {
+      Logger.debug(`warm-analyze: base ref ${baseSha} unreachable → full fallback`);
+      mode = "full";
+    } else {
+      try {
+        const run = makeDefaultGitRunner(process.cwd());
+        deltaResult = computeDelta(baseSha, { run, maxBytes });
+        mode = decideMode({
+          hasBaseline: true,
+          deltaBytes: Buffer.byteLength(deltaResult.diff, "utf8"),
+          maxBytes,
+          baseReachable: true,
+        });
+      } catch (err) {
+        Logger.error(
+          `warm-analyze: computeDelta failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+        mode = "full";
+      }
+    }
+
+    if (mode === "delta" && deltaResult) {
+      // ── Incremental delta mode ───────────────────────────────────────────
+      Logger.debug(
+        `warm-analyze: delta mode — ${deltaResult.changedFiles.length} changed files`
+      );
+      const deltaPrompt = buildDeltaPrompt({
+        userPrompt: prompt as string,
+        baseRef: deltaResult.baseRef,
+        headRef: deltaResult.headRef,
+        changedFiles: deltaResult.changedFiles,
+        diff: deltaResult.diff,
+        truncated: deltaResult.truncated,
+      });
+
+      onProgress?.("Sending incremental diff to Gemini...");
+      const result = await executeGeminiCLI(
+        deltaPrompt,
+        model as string | undefined,
+        false,
+        false,
+        onProgress
+      );
+      return `${STATUS_MESSAGES.GEMINI_RESPONSE}\n${result}`;
+    }
+
+    // ── Full fallback ─────────────────────────────────────────────────────────
+    Logger.debug("warm-analyze: full fallback — updating baseline");
+    setBaseline(currentHead);
+
+    const fallbackNote =
+      "\n\n> **warm-analyze:** Delta was too large or the baseline was unreachable. " +
+      "Ran a full-workspace analysis and recorded a new baseline.";
+
+    onProgress?.(STATUS_MESSAGES.PROCESSING_START);
+    const result = await executeGeminiCLI(
+      prompt as string,
+      model as string | undefined,
+      false,
+      false,
+      onProgress
+    );
+    return `${STATUS_MESSAGES.GEMINI_RESPONSE}\n${result}${fallbackNote}`;
+  },
+};

--- a/src/utils/repoDelta.ts
+++ b/src/utils/repoDelta.ts
@@ -1,0 +1,152 @@
+/**
+ * repoDelta.ts
+ *
+ * Utilities for computing an incremental git diff between a baseline ref and HEAD.
+ * The GitRunner type is injectable so unit tests can supply a pure-function fake
+ * without spawning a real subprocess.
+ */
+import { spawnSync } from "child_process";
+import * as path from "path";
+import { Logger } from "./logger.js";
+
+/** A synchronous function that runs git with the given args and returns stdout. */
+export type GitRunner = (args: string[]) => string;
+
+export interface DeltaResult {
+  baseRef: string;
+  headRef: string;
+  changedFiles: string[];
+  diff: string;
+  truncated: boolean;
+}
+
+export interface DecideInput {
+  hasBaseline: boolean;
+  deltaBytes: number;
+  maxBytes: number;
+  baseReachable: boolean;
+}
+
+export type AnalysisMode = "delta" | "full";
+
+/** Default max diff size: 200 KB. */
+const DEFAULT_MAX_BYTES = 200_000;
+
+/**
+ * Build the default GitRunner that shells out to the real git binary.
+ * All paths are confined to cwd, and args are passed as an argv array (no shell string).
+ */
+export function makeDefaultGitRunner(cwd: string = process.cwd()): GitRunner {
+  const normalizedCwd = path.resolve(cwd);
+  return (args: string[]): string => {
+    const result = spawnSync("git", args, {
+      cwd: normalizedCwd,
+      encoding: "utf8",
+      // Never produce a shell string from user input — args are passed verbatim.
+      shell: false,
+    });
+    if (result.error) {
+      throw new Error(`git failed: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `git ${args[0] ?? ""} exited with status ${result.status}: ${(result.stderr ?? "").trim()}`
+      );
+    }
+    return (result.stdout ?? "").trim();
+  };
+}
+
+/**
+ * Compute the incremental diff between `baseRef` and HEAD.
+ *
+ * @param baseRef - A git ref (SHA, branch, tag) to treat as the baseline.
+ * @param opts.run      - Injected GitRunner; defaults to the real git binary.
+ * @param opts.maxBytes - Cap for the diff text (default 200 000 bytes).
+ * @returns DeltaResult describing changed files and the raw diff.
+ */
+export function computeDelta(
+  baseRef: string,
+  opts: { run?: GitRunner; maxBytes?: number } = {}
+): DeltaResult {
+  const run = opts.run ?? makeDefaultGitRunner();
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  Logger.debug(`repoDelta: computing delta from ${baseRef}`);
+
+  // Resolve the current HEAD commit SHA.
+  const headRef = run(["rev-parse", "HEAD"]);
+
+  // Obtain the list of files changed between baseRef and HEAD.
+  const nameOnlyOutput = run(["diff", "--name-only", `${baseRef}..HEAD`]);
+  const committedFiles = nameOnlyOutput
+    ? nameOnlyOutput.split("\n").filter(Boolean)
+    : [];
+
+  // Also capture untracked / modified working-tree files via `git status`.
+  const statusOutput = run(["status", "--porcelain"]);
+  const workingFiles = statusOutput
+    ? statusOutput
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => line.slice(3).trim())
+        .filter(Boolean)
+    : [];
+
+  // Deduplicate the combined file list.
+  const changedFiles = [
+    ...new Set([...committedFiles, ...workingFiles]),
+  ];
+
+  // Obtain the full diff text.
+  const rawDiff = run(["diff", `${baseRef}..HEAD`]);
+
+  let diff: string;
+  let truncated: boolean;
+
+  if (Buffer.byteLength(rawDiff, "utf8") > maxBytes) {
+    // Truncate to the byte cap using a character-level approximation.
+    // We slice to maxBytes characters (UTF-8 multi-byte chars are unusual in
+    // diff output; this is a best-effort limit, not a cryptographic one).
+    diff = rawDiff.slice(0, maxBytes);
+    truncated = true;
+    Logger.debug(
+      `repoDelta: diff truncated at ${maxBytes} bytes (raw was ${rawDiff.length} chars)`
+    );
+  } else {
+    diff = rawDiff;
+    truncated = false;
+  }
+
+  return { baseRef, headRef, changedFiles, diff, truncated };
+}
+
+/**
+ * Decide whether the next analysis should send the full workspace or just
+ * the incremental delta.
+ *
+ * Returns 'full' when:
+ *   - there is no baseline to diff from (fresh session),
+ *   - the computed delta exceeds the byte budget (too large for a focused review),
+ *   - or the base ref is not reachable in the repo (e.g. shallow clone, force-push).
+ *
+ * Returns 'delta' otherwise.
+ */
+export function decideMode(opts: DecideInput): AnalysisMode {
+  if (!opts.hasBaseline) {
+    Logger.debug("decideMode: no baseline → full");
+    return "full";
+  }
+  if (!opts.baseReachable) {
+    Logger.debug("decideMode: base ref unreachable → full");
+    return "full";
+  }
+  if (opts.deltaBytes > opts.maxBytes) {
+    Logger.debug(
+      `decideMode: delta (${opts.deltaBytes}B) exceeds max (${opts.maxBytes}B) → full`
+    );
+    return "full";
+  }
+  Logger.debug("decideMode: delta mode");
+  return "delta";
+}

--- a/src/utils/residencyState.ts
+++ b/src/utils/residencyState.ts
@@ -1,0 +1,100 @@
+/**
+ * residencyState.ts
+ *
+ * Persists the warm-residency baseline { baseSha, createdAt } to a JSON file
+ * inside the state directory.  The state directory path is derived from the
+ * GEMINI_MCP_STATE_DIR environment variable (default: '.gemini-mcp') resolved
+ * relative to process.cwd().
+ *
+ * Security: all paths are confined within process.cwd() – no user-supplied
+ * path components reach the filesystem.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { GEMINI_MCP_STATE_DIR } from "../constants.js";
+import { Logger } from "./logger.js";
+
+export interface ResidencyBaseline {
+  baseSha: string;
+  createdAt: string; // ISO 8601
+}
+
+/** Resolve the state directory, anchored at process.cwd(). */
+function stateDir(): string {
+  const dirName = process.env[GEMINI_MCP_STATE_DIR] ?? ".gemini-mcp";
+  const resolved = path.resolve(process.cwd(), dirName);
+  // Prevent escaping the working directory.
+  const cwd = path.resolve(process.cwd());
+  if (resolved !== cwd && !resolved.startsWith(cwd + path.sep)) {
+    throw new Error(
+      `GEMINI_MCP_STATE_DIR resolves outside the project directory: "${resolved}"`
+    );
+  }
+  return resolved;
+}
+
+function residencyFilePath(): string {
+  return path.join(stateDir(), "residency.json");
+}
+
+/** Lazily create the state directory. */
+function ensureStateDir(): void {
+  const dir = stateDir();
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    Logger.debug(`residencyState: created state directory: ${dir}`);
+  }
+}
+
+/**
+ * Read the persisted baseline, or return null if none exists.
+ */
+export function getBaseline(): ResidencyBaseline | null {
+  const fp = residencyFilePath();
+  if (!fs.existsSync(fp)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(fp, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "baseSha" in parsed &&
+      "createdAt" in parsed &&
+      typeof (parsed as { baseSha: unknown }).baseSha === "string" &&
+      typeof (parsed as { createdAt: unknown }).createdAt === "string"
+    ) {
+      return parsed as ResidencyBaseline;
+    }
+    Logger.debug("residencyState: residency.json has unexpected shape, ignoring");
+    return null;
+  } catch (err) {
+    Logger.debug(`residencyState: failed to read baseline: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Persist a new baseline SHA, recording the current timestamp.
+ */
+export function setBaseline(sha: string): void {
+  ensureStateDir();
+  const baseline: ResidencyBaseline = {
+    baseSha: sha,
+    createdAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(residencyFilePath(), JSON.stringify(baseline, null, 2), "utf8");
+  Logger.debug(`residencyState: baseline set to ${sha}`);
+}
+
+/**
+ * Remove the persisted baseline (clears warm-residency state).
+ */
+export function clearBaseline(): void {
+  const fp = residencyFilePath();
+  if (fs.existsSync(fp)) {
+    fs.unlinkSync(fp);
+    Logger.debug("residencyState: baseline cleared");
+  }
+}

--- a/test/integration/warm-residency.test.ts
+++ b/test/integration/warm-residency.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Integration tests for warm-residency: computeDelta (real git) and
+ * residencyState round-trip.
+ *
+ * git is available in this environment; no Gemini CLI is involved.
+ * Each test creates its own isolated temporary directory so tests can run
+ * serially without side effects.
+ */
+import { test, describe, after } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { spawnSync } from "child_process";
+
+import { computeDelta, makeDefaultGitRunner } from "../../src/utils/repoDelta.js";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/** Create a temporary directory and return its path. */
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Remove a temp dir after use. */
+function rmrf(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/** Run a git command in a dir, throw on failure. */
+function git(cwd: string, ...args: string[]): string {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8", shell: false });
+  if (r.status !== 0 || r.error) {
+    throw new Error(`git ${args[0]}: ${(r.stderr ?? "").trim() || r.error?.message}`);
+  }
+  return (r.stdout ?? "").trim();
+}
+
+/**
+ * Bootstrap a minimal git repo: init, set identity, create an initial commit.
+ * Returns the SHA of the initial commit.
+ */
+function bootstrapRepo(dir: string): string {
+  git(dir, "init");
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "Test");
+  // Ensure branch is named 'main' regardless of system defaults.
+  git(dir, "checkout", "-b", "main");
+  const readmePath = path.join(dir, "README.md");
+  fs.writeFileSync(readmePath, "# test repo\n", "utf8");
+  git(dir, "add", "README.md");
+  git(dir, "commit", "-m", "chore: initial commit");
+  return git(dir, "rev-parse", "HEAD");
+}
+
+// ─── computeDelta integration ─────────────────────────────────────────────────
+
+describe("Integration: computeDelta with real git", () => {
+  const dirs: string[] = [];
+  after(() => dirs.forEach(rmrf));
+
+  test("detects a new file added after the baseline commit", () => {
+    const dir = makeTempDir("warm-delta-");
+    dirs.push(dir);
+
+    const baseSha = bootstrapRepo(dir);
+
+    // Add a new file and commit it.
+    fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "src", "new.ts"), "export {};", "utf8");
+    git(dir, "add", ".");
+    git(dir, "commit", "-m", "feat: add new.ts");
+
+    const run = makeDefaultGitRunner(dir);
+    const result = computeDelta(baseSha, { run });
+
+    assert.ok(result.changedFiles.includes("src/new.ts"), "should include src/new.ts");
+    assert.ok(result.diff.includes("new.ts"), "diff should mention new.ts");
+    assert.strictEqual(result.baseRef, baseSha);
+    assert.notStrictEqual(result.headRef, baseSha, "headRef differs from base after commit");
+    assert.strictEqual(result.truncated, false);
+  });
+
+  test("detects a modification to an existing file", () => {
+    const dir = makeTempDir("warm-delta-mod-");
+    dirs.push(dir);
+
+    const baseSha = bootstrapRepo(dir);
+
+    // Modify the README after baseline.
+    fs.writeFileSync(path.join(dir, "README.md"), "# updated\n", "utf8");
+    git(dir, "add", "README.md");
+    git(dir, "commit", "-m", "docs: update readme");
+
+    const run = makeDefaultGitRunner(dir);
+    const result = computeDelta(baseSha, { run });
+
+    assert.ok(result.changedFiles.includes("README.md"));
+    assert.ok(result.diff.includes("updated"));
+  });
+
+  test("returns empty changedFiles and diff when there are no commits after baseline", () => {
+    const dir = makeTempDir("warm-delta-empty-");
+    dirs.push(dir);
+
+    const baseSha = bootstrapRepo(dir);
+
+    const run = makeDefaultGitRunner(dir);
+    const result = computeDelta(baseSha, { run });
+
+    // HEAD equals base — no diff.
+    assert.strictEqual(result.headRef, baseSha);
+    assert.deepStrictEqual(result.changedFiles, []);
+    assert.strictEqual(result.diff, "");
+    assert.strictEqual(result.truncated, false);
+  });
+
+  test("respects maxBytes and marks truncated when diff is huge", () => {
+    const dir = makeTempDir("warm-delta-trunc-");
+    dirs.push(dir);
+
+    const baseSha = bootstrapRepo(dir);
+
+    // Write a large file to exceed a tiny cap.
+    fs.writeFileSync(path.join(dir, "big.txt"), "z".repeat(2000), "utf8");
+    git(dir, "add", "big.txt");
+    git(dir, "commit", "-m", "chore: big file");
+
+    const run = makeDefaultGitRunner(dir);
+    const result = computeDelta(baseSha, { run, maxBytes: 50 });
+
+    assert.strictEqual(result.truncated, true);
+    assert.ok(result.diff.length <= 50);
+  });
+});
+
+// ─── residencyState round-trip integration ────────────────────────────────────
+
+describe("Integration: residencyState round-trip", () => {
+  const dirs: string[] = [];
+  after(() => dirs.forEach(rmrf));
+
+  test("getBaseline returns null when no state file exists", async () => {
+    const tmpDir = makeTempDir("warm-state-");
+    dirs.push(tmpDir);
+
+    const origCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      // Import fresh to respect the new cwd.
+      const { getBaseline } = await import("../../src/utils/residencyState.js");
+      const result = getBaseline();
+      assert.strictEqual(result, null);
+    } finally {
+      process.chdir(origCwd);
+    }
+  });
+
+  test("setBaseline persists SHA and getBaseline reads it back", async () => {
+    const tmpDir = makeTempDir("warm-state-rw-");
+    dirs.push(tmpDir);
+
+    const origCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      const { getBaseline, setBaseline, clearBaseline } =
+        await import("../../src/utils/residencyState.js");
+
+      // Start clean.
+      clearBaseline();
+      assert.strictEqual(getBaseline(), null);
+
+      const sha = "abc123def456";
+      setBaseline(sha);
+
+      const got = getBaseline();
+      assert.ok(got !== null, "baseline should be set");
+      assert.strictEqual(got.baseSha, sha);
+      assert.ok(got.createdAt, "createdAt should be populated");
+      assert.doesNotThrow(() => new Date(got.createdAt), "createdAt should be a valid ISO date");
+
+      // Verify the file is in the expected directory.
+      const stateFile = path.join(tmpDir, ".gemini-mcp", "residency.json");
+      assert.ok(fs.existsSync(stateFile), "residency.json should exist");
+
+      // clearBaseline should remove it.
+      clearBaseline();
+      assert.strictEqual(getBaseline(), null);
+      assert.ok(!fs.existsSync(stateFile), "residency.json should be gone after clear");
+    } finally {
+      process.chdir(origCwd);
+    }
+  });
+
+  test("setBaseline overwrites an earlier baseline", async () => {
+    const tmpDir = makeTempDir("warm-state-overwrite-");
+    dirs.push(tmpDir);
+
+    const origCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      const { getBaseline, setBaseline, clearBaseline } =
+        await import("../../src/utils/residencyState.js");
+
+      clearBaseline();
+      setBaseline("sha-first");
+      setBaseline("sha-second");
+
+      const got = getBaseline();
+      assert.ok(got !== null);
+      assert.strictEqual(got.baseSha, "sha-second");
+    } finally {
+      process.chdir(origCwd);
+    }
+  });
+
+  test("GEMINI_MCP_STATE_DIR env override changes the storage directory", async () => {
+    const tmpDir = makeTempDir("warm-state-envdir-");
+    dirs.push(tmpDir);
+    const customSubdir = "my-custom-state";
+
+    const origCwd = process.cwd();
+    const origEnv = process.env["GEMINI_MCP_STATE_DIR"];
+    process.chdir(tmpDir);
+    process.env["GEMINI_MCP_STATE_DIR"] = customSubdir;
+
+    try {
+      const { getBaseline, setBaseline, clearBaseline } =
+        await import("../../src/utils/residencyState.js");
+
+      clearBaseline();
+      setBaseline("env-sha");
+
+      const customFile = path.join(tmpDir, customSubdir, "residency.json");
+      assert.ok(
+        fs.existsSync(customFile),
+        `residency.json should exist at custom path: ${customFile}`
+      );
+
+      const got = getBaseline();
+      assert.ok(got !== null);
+      assert.strictEqual(got.baseSha, "env-sha");
+
+      clearBaseline();
+    } finally {
+      process.chdir(origCwd);
+      if (origEnv === undefined) {
+        delete process.env["GEMINI_MCP_STATE_DIR"];
+      } else {
+        process.env["GEMINI_MCP_STATE_DIR"] = origEnv;
+      }
+    }
+  });
+});

--- a/test/unit/utils/repoDelta.test.ts
+++ b/test/unit/utils/repoDelta.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for repoDelta.ts
+ *
+ * All tests use a fake GitRunner — no real git subprocess is invoked.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { computeDelta, decideMode } from "../../../src/utils/repoDelta.js";
+
+// ─── Fake GitRunner factory ───────────────────────────────────────────────────
+
+interface FakeGitConfig {
+  head?: string;
+  nameOnly?: string;   // newline-separated changed files
+  diff?: string;       // full diff text
+  statusPorcelain?: string;
+}
+
+function makeFakeGitRunner(cfg: FakeGitConfig) {
+  return (args: string[]): string => {
+    const sub = args[0];
+    if (sub === "rev-parse" && args[1] === "HEAD") {
+      return cfg.head ?? "aabbccdd1234";
+    }
+    if (sub === "diff" && args[1] === "--name-only") {
+      return cfg.nameOnly ?? "";
+    }
+    if (sub === "diff" && args.length === 2) {
+      // git diff <base>..HEAD
+      return cfg.diff ?? "";
+    }
+    if (sub === "status" && args[1] === "--porcelain") {
+      return cfg.statusPorcelain ?? "";
+    }
+    return "";
+  };
+}
+
+// ─── computeDelta ─────────────────────────────────────────────────────────────
+
+describe("repoDelta: computeDelta", () => {
+  test("returns headRef from rev-parse HEAD", () => {
+    const run = makeFakeGitRunner({ head: "deadbeef1234" });
+    const result = computeDelta("base1234", { run });
+    assert.strictEqual(result.headRef, "deadbeef1234");
+  });
+
+  test("returns the supplied baseRef unchanged", () => {
+    const run = makeFakeGitRunner({});
+    const result = computeDelta("mybase", { run });
+    assert.strictEqual(result.baseRef, "mybase");
+  });
+
+  test("parses changedFiles from --name-only output", () => {
+    const run = makeFakeGitRunner({
+      nameOnly: "src/foo.ts\nsrc/bar.ts",
+    });
+    const result = computeDelta("base", { run });
+    assert.deepStrictEqual(result.changedFiles, ["src/foo.ts", "src/bar.ts"]);
+  });
+
+  test("merges working-tree files from git status --porcelain", () => {
+    const run = makeFakeGitRunner({
+      nameOnly: "src/committed.ts",
+      statusPorcelain: "?? src/untracked.ts\n M src/modified.ts",
+    });
+    const result = computeDelta("base", { run });
+    assert.ok(result.changedFiles.includes("src/committed.ts"));
+    assert.ok(result.changedFiles.includes("src/untracked.ts"));
+    assert.ok(result.changedFiles.includes("src/modified.ts"));
+  });
+
+  test("deduplicates files that appear in both diff and status", () => {
+    const run = makeFakeGitRunner({
+      nameOnly: "src/dupe.ts",
+      statusPorcelain: "M  src/dupe.ts",
+    });
+    const result = computeDelta("base", { run });
+    assert.strictEqual(result.changedFiles.filter((f) => f === "src/dupe.ts").length, 1);
+  });
+
+  test("returns the diff text in result.diff", () => {
+    const fakeDiff = "diff --git a/src/x.ts b/src/x.ts\n+added line";
+    const run = makeFakeGitRunner({ diff: fakeDiff });
+    const result = computeDelta("base", { run });
+    assert.strictEqual(result.diff, fakeDiff);
+    assert.strictEqual(result.truncated, false);
+  });
+
+  test("truncates diff when it exceeds maxBytes", () => {
+    const largeDiff = "x".repeat(500);
+    const run = makeFakeGitRunner({ diff: largeDiff });
+    const result = computeDelta("base", { run, maxBytes: 100 });
+    assert.strictEqual(result.diff.length, 100);
+    assert.strictEqual(result.truncated, true);
+  });
+
+  test("does not truncate when diff is exactly at the cap", () => {
+    const exactDiff = "y".repeat(100);
+    const run = makeFakeGitRunner({ diff: exactDiff });
+    const result = computeDelta("base", { run, maxBytes: 100 });
+    assert.strictEqual(result.diff.length, 100);
+    assert.strictEqual(result.truncated, false);
+  });
+
+  test("returns empty changedFiles and empty diff when there are no changes", () => {
+    const run = makeFakeGitRunner({ nameOnly: "", diff: "", statusPorcelain: "" });
+    const result = computeDelta("base", { run });
+    assert.deepStrictEqual(result.changedFiles, []);
+    assert.strictEqual(result.diff, "");
+    assert.strictEqual(result.truncated, false);
+  });
+
+  test("throws when the GitRunner throws (e.g. not a git repo)", () => {
+    const brokenRun = (_args: string[]): string => {
+      throw new Error("not a git repository");
+    };
+    assert.throws(() => computeDelta("base", { run: brokenRun }), /not a git repository/);
+  });
+});
+
+// ─── decideMode ──────────────────────────────────────────────────────────────
+
+describe("repoDelta: decideMode", () => {
+  test("returns 'full' when hasBaseline is false", () => {
+    assert.strictEqual(
+      decideMode({ hasBaseline: false, deltaBytes: 0, maxBytes: 200_000, baseReachable: true }),
+      "full"
+    );
+  });
+
+  test("returns 'full' when baseReachable is false", () => {
+    assert.strictEqual(
+      decideMode({ hasBaseline: true, deltaBytes: 100, maxBytes: 200_000, baseReachable: false }),
+      "full"
+    );
+  });
+
+  test("returns 'full' when deltaBytes exceeds maxBytes", () => {
+    assert.strictEqual(
+      decideMode({ hasBaseline: true, deltaBytes: 300_000, maxBytes: 200_000, baseReachable: true }),
+      "full"
+    );
+  });
+
+  test("returns 'delta' when baseline exists, base is reachable, and delta fits", () => {
+    assert.strictEqual(
+      decideMode({ hasBaseline: true, deltaBytes: 50_000, maxBytes: 200_000, baseReachable: true }),
+      "delta"
+    );
+  });
+
+  test("returns 'delta' when deltaBytes is exactly maxBytes", () => {
+    // Not strictly > maxBytes, so should be delta.
+    assert.strictEqual(
+      decideMode({ hasBaseline: true, deltaBytes: 200_000, maxBytes: 200_000, baseReachable: true }),
+      "delta"
+    );
+  });
+
+  test("returns 'full' when deltaBytes is maxBytes + 1", () => {
+    assert.strictEqual(
+      decideMode({ hasBaseline: true, deltaBytes: 200_001, maxBytes: 200_000, baseReachable: true }),
+      "full"
+    );
+  });
+
+  test("returns 'full' when both hasBaseline and baseReachable are false", () => {
+    assert.strictEqual(
+      decideMode({ hasBaseline: false, deltaBytes: 0, maxBytes: 200_000, baseReachable: false }),
+      "full"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `warm-analyze`, a tool that tracks a baseline commit SHA and, on follow-up analyses, sends only the incremental `git diff` since that baseline instead of re-shipping the whole workspace — reducing token usage and latency for iterative review sessions.

## What changes

- `src/utils/repoDelta.ts` — an injectable `GitRunner` type so the delta-computation logic is fully unit-testable without spawning a real subprocess. The default runner uses `spawnSync("git", argv, { shell: false })`; no shell string is constructed from input, and the working directory is confined to `process.cwd()`.
- `src/utils/residencyState.ts` — persists `{ baseSha, createdAt }` to `<GEMINI_MCP_STATE_DIR>/residency.json` (default `.gemini-mcp/`).
- `decideMode` is a pure function selecting `delta` vs `full`, falling back to full-workspace analysis when there is no baseline, when the base ref is unreachable, or when the diff exceeds the configured byte budget (`GEMINI_MCP_MAX_DELTA_BYTES`, default 200 000).

## Verification

- `npx tsc --noEmit` — clean
- `node scripts/run-tests.mjs unit integration` — 82 pass / 0 fail (17 new unit tests for `computeDelta`/`decideMode`; 8 new integration tests using a real temp git repo + the `residencyState` round-trip)

## Notes

- Opt-in: a new tool; no existing behavior changes.
- State and git operations anchor to `process.cwd()`; if the server's working directory differs from the project root, set `GEMINI_MCP_STATE_DIR` explicitly.