### PR TITLE
feat: map-reduce analysis across sharded workspaces

### DIFF
--- a/docs/concepts/map-reduce.md
+++ b/docs/concepts/map-reduce.md
@@ -1,0 +1,67 @@
+# Map-Reduce Analysis
+
+The `map-reduce-analyze` tool enables analysis of codebases that are too large to fit within a single Gemini context window. It works by sharding the workspace into manageable pieces, running Gemini on each shard in parallel, and then synthesizing the individual results into one coherent answer.
+
+## How It Works
+
+### 1. File Collection
+
+The tool walks the target directory recursively, collecting all files and their byte sizes. Common noise directories (`node_modules`, `.git`, `dist`, `.gemini-mcp`, `.tmptest`) are skipped automatically.
+
+### 2. Sharding
+
+Files are greedy bin-packed into shards so that each shard stays close to the target size (`shardBytes`, default 800 KB). The algorithm:
+
+- Never splits a file across two shards.
+- Preserves input order within and across shards.
+- Places an oversized file (larger than `shardBytes`) in its own shard.
+
+### 3. Map Phase
+
+Each shard is sent to Gemini with the user's prompt and the shard's file references. Shards run in parallel, bounded by the `concurrency` setting (default 4, capped at 10). A shard failure is recorded but does not abort the rest of the run.
+
+### 4. Reduce Phase
+
+When there is more than one shard, the per-shard answers are collected and sent to Gemini again with a synthesis prompt. The final output is this synthesized answer.
+
+If only one shard is needed, the reduce step is skipped and the single map result is returned directly.
+
+## Usage
+
+```
+map-reduce-analyze(
+  prompt: "Identify all potential security vulnerabilities",
+  paths: "src",
+  concurrency: 4,
+  shardBytes: 800000
+)
+```
+
+### Parameters
+
+| Parameter     | Required | Default                               | Description |
+|---------------|----------|---------------------------------------|-------------|
+| `prompt`      | Yes      | —                                     | The analysis question applied to the whole workspace. |
+| `paths`       | No       | `.`                                   | Root directory to analyze, relative to the project root. |
+| `concurrency` | No       | `GEMINI_MCP_MAP_CONCURRENCY` or `4`  | Max parallel Gemini calls (clamped to 1–10). |
+| `shardBytes`  | No       | `800000`                              | Target bytes per shard. Raise this to produce fewer shards. |
+
+## Configuration
+
+Set `GEMINI_MCP_MAP_CONCURRENCY` in the environment to change the default concurrency for all map-reduce calls without passing it explicitly each time.
+
+## Limits
+
+- **Maximum shards: 50.** If the workspace produces more than 50 shards at the given `shardBytes`, the tool returns an error with guidance on how to increase `shardBytes` to stay within the limit.
+- **Concurrency: 1–10.** Values outside this range are clamped automatically.
+- **Path confinement.** All file access is restricted to the project directory. Paths that resolve outside it are rejected.
+
+## When to Use
+
+Use `map-reduce-analyze` when:
+
+- `ask-gemini` times out or hits context-length limits on a large codebase.
+- You need a whole-repository view (architecture summaries, security audits, dependency graphs).
+- You want a thorough, complete analysis rather than a sample.
+
+For targeted questions about specific files, `ask-gemini` with `@file` references remains the faster option.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const ERROR_MESSAGES = {
   QUOTA_EXCEEDED_SHORT: "⚠️ Gemini 2.5 Pro daily quota exceeded. Please retry with model: 'gemini-2.5-flash'",
   TOOL_NOT_FOUND: "not found in registry",
   NO_PROMPT_PROVIDED: "Please provide a prompt for analysis. Use @ syntax to include files (e.g., '@largefile.js explain what this does') or ask general questions",
+  MAP_REDUCE_TOO_MANY_SHARDS: "Too many shards generated. Increase shardBytes to reduce the number of shards, or narrow the target paths.",
 } as const;
 
 // Status messages
@@ -22,6 +23,10 @@ export const STATUS_MESSAGES = {
   PROCESSING_START: "🔍 Starting analysis (may take 5-15 minutes for large codebases)",
   PROCESSING_CONTINUE: "⏳ Still processing... Gemini is working on your request",
   PROCESSING_COMPLETE: "✅ Analysis completed successfully",
+  // Map-reduce messages
+  MAP_REDUCE_SHARDING: "Sharding workspace",
+  MAP_REDUCE_MAPPING: "Analyzing shard",
+  MAP_REDUCE_REDUCING: "Synthesizing results across shards",
 } as const;
 
 // Models
@@ -83,6 +88,7 @@ export const CLI = {
 // Environment variables that configure the server.
 export const ENV = {
   GEMINI_CLI_PATH: "GEMINI_CLI_PATH", // explicit path to the gemini executable (Windows shim resolution)
+  GEMINI_MCP_MAP_CONCURRENCY: "GEMINI_MCP_MAP_CONCURRENCY", // max parallel Gemini calls in map-reduce (default 4)
 } as const;
 
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,13 +5,15 @@ import { pingTool, helpTool } from './simple-tools.js';
 import { brainstormTool } from './brainstorm.tool.js';
 import { fetchChunkTool } from './fetch-chunk.tool.js';
 import { timeoutTestTool } from './timeout-test.tool.js';
+import { mapReduceAnalyzeTool } from './map-reduce-analyze.tool.js';
 
 toolRegistry.push(
   askGeminiTool,
   pingTool,
   helpTool,
   brainstormTool,
-  fetchChunkTool
+  fetchChunkTool,
+  mapReduceAnalyzeTool
 );
 
 // Only register test-only tools when explicitly enabled (e.g. judge/e2e test suite)

--- a/src/tools/map-reduce-analyze.tool.ts
+++ b/src/tools/map-reduce-analyze.tool.ts
@@ -1,0 +1,220 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import { UnifiedTool } from './registry.js';
+import { executeGeminiCLI } from '../utils/geminiExecutor.js';
+import { collectFiles, planShards, Shard } from '../utils/sharding.js';
+import { mapReduce } from '../utils/mapReduce.js';
+import { Logger } from '../utils/logger.js';
+import {
+  ENV,
+  ERROR_MESSAGES,
+  STATUS_MESSAGES,
+} from '../constants.js';
+
+/** Hard limit on the number of shards to prevent runaway API costs. */
+const MAX_SHARDS = 50;
+
+/** Default shard size if not specified by the caller. */
+const DEFAULT_SHARD_BYTES = 800_000;
+
+/** Clamp the requested concurrency to a safe range. */
+function clampConcurrency(raw: number): number {
+  return Math.max(1, Math.min(10, raw));
+}
+
+/** Read the default concurrency from the environment, falling back to 4. */
+function defaultConcurrency(): number {
+  const raw = process.env[ENV.GEMINI_MCP_MAP_CONCURRENCY];
+  if (!raw) return 4;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) ? clampConcurrency(parsed) : 4;
+}
+
+/**
+ * Build the per-shard prompt that asks Gemini to analyze the files in one shard.
+ * File paths are referenced with the `@` syntax so the Gemini CLI inlines them.
+ */
+function buildMapPrompt(userPrompt: string, shard: Shard, shardIndex: number, totalShards: number): string {
+  const fileRefs = shard.files.map((f) => `@${f.path}`).join(' ');
+  return (
+    `[Shard ${shardIndex + 1} of ${totalShards}]\n` +
+    `Analyze the following files and answer this question as it applies to them:\n\n` +
+    `${userPrompt}\n\n` +
+    `Files in this shard:\n${fileRefs}`
+  );
+}
+
+/**
+ * Build the reduce prompt that asks Gemini to synthesize the per-shard answers.
+ */
+function buildReducePrompt(userPrompt: string, shardAnswers: string[]): string {
+  const answersBlock = shardAnswers
+    .map((ans, i) => `--- Shard ${i + 1} answer ---\n${ans}`)
+    .join('\n\n');
+
+  return (
+    `You have received partial analysis results from ${shardAnswers.length} ` +
+    `independent code shards. Synthesize them into a single, coherent answer ` +
+    `to the original question:\n\n` +
+    `ORIGINAL QUESTION:\n${userPrompt}\n\n` +
+    `SHARD ANSWERS:\n${answersBlock}\n\n` +
+    `Provide a unified, comprehensive answer that integrates all findings.`
+  );
+}
+
+const mapReduceAnalyzeSchema = z.object({
+  prompt: z
+    .string()
+    .min(1)
+    .describe(
+      'Analysis question or instruction to apply across the entire workspace ' +
+      '(e.g. "Find all security vulnerabilities" or "Summarize the architecture").',
+    ),
+  paths: z
+    .string()
+    .optional()
+    .default('.')
+    .describe(
+      'Workspace root to analyze, relative to the project directory (default: ".").',
+    ),
+  concurrency: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      `Maximum number of parallel Gemini calls (1–10, default ${defaultConcurrency()}). ` +
+      `Overrides ${ENV.GEMINI_MCP_MAP_CONCURRENCY}.`,
+    ),
+  shardBytes: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(DEFAULT_SHARD_BYTES)
+    .describe(
+      `Target bytes per shard (default ${DEFAULT_SHARD_BYTES}). Larger values ` +
+      `produce fewer, bigger shards and fewer Gemini calls.`,
+    ),
+});
+
+export const mapReduceAnalyzeTool: UnifiedTool = {
+  name: 'map-reduce-analyze',
+  description:
+    'Analyze a large workspace by sharding it into manageable pieces, running ' +
+    'Gemini on each shard in parallel, then synthesizing the results into one ' +
+    'coherent answer. Use this when the codebase is too large for a single context.',
+  zodSchema: mapReduceAnalyzeSchema,
+  category: 'gemini',
+  prompt: {
+    description:
+      'Run a map-reduce analysis across sharded workspace files using Gemini.',
+  },
+
+  execute: async (args, onProgress) => {
+    const {
+      prompt,
+      paths: rawPaths = '.',
+      concurrency: rawConcurrency,
+      shardBytes = DEFAULT_SHARD_BYTES,
+    } = args;
+
+    const concurrency = clampConcurrency(
+      rawConcurrency != null ? (rawConcurrency as number) : defaultConcurrency(),
+    );
+
+    // ---- Confine the search root to process.cwd() ----
+    const cwd = process.cwd();
+    const resolvedRoot = path.resolve(cwd, rawPaths as string);
+    const normalizedCwd = path.resolve(cwd);
+    const escapesRoot =
+      resolvedRoot !== normalizedCwd &&
+      !resolvedRoot.startsWith(normalizedCwd + path.sep);
+
+    if (escapesRoot) {
+      return (
+        `❌ The "paths" argument resolves to "${resolvedRoot}", which is outside ` +
+        `the project directory "${normalizedCwd}". Only paths within the project ` +
+        `directory are permitted.`
+      );
+    }
+
+    // ---- Collect files ----
+    onProgress?.(`${STATUS_MESSAGES.MAP_REDUCE_SHARDING}: ${resolvedRoot}`);
+    Logger.debug(`map-reduce-analyze: collecting files under "${resolvedRoot}"`);
+
+    let files: Array<{ path: string; bytes: number }>;
+    try {
+      files = collectFiles(resolvedRoot);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return `❌ Failed to collect files: ${msg}`;
+    }
+
+    if (files.length === 0) {
+      return `❌ No files found under "${resolvedRoot}".`;
+    }
+
+    // ---- Plan shards ----
+    const shards = planShards(files, shardBytes as number);
+    Logger.debug(`map-reduce-analyze: ${files.length} files → ${shards.length} shards`);
+
+    if (shards.length > MAX_SHARDS) {
+      return (
+        `❌ ${ERROR_MESSAGES.MAP_REDUCE_TOO_MANY_SHARDS}\n` +
+        `Generated ${shards.length} shards (limit: ${MAX_SHARDS}). ` +
+        `Current shardBytes: ${shardBytes}. ` +
+        `Try increasing shardBytes to at least ${Math.ceil((shardBytes as number) * (shards.length / MAX_SHARDS))}.`
+      );
+    }
+
+    onProgress?.(`${STATUS_MESSAGES.MAP_REDUCE_SHARDING}: ${shards.length} shards, concurrency=${concurrency}`);
+
+    // ---- Short-circuit: single shard ----
+    if (shards.length === 1) {
+      onProgress?.(`Single shard — running direct analysis`);
+      const mapPrompt = buildMapPrompt(prompt as string, shards[0], 0, 1);
+      const result = await executeGeminiCLI(mapPrompt, undefined, false, false, onProgress);
+      return result;
+    }
+
+    // ---- Map phase ----
+    const shardAnswers: string[] = new Array(shards.length).fill('');
+
+    const { errors } = await mapReduce<Shard, string, void>({
+      shards,
+      concurrency,
+      mapFn: async (shard, i) => {
+        onProgress?.(`${STATUS_MESSAGES.MAP_REDUCE_MAPPING} ${i + 1}/${shards.length}`);
+        const mapPrompt = buildMapPrompt(prompt as string, shard, i, shards.length);
+        const answer = await executeGeminiCLI(mapPrompt, undefined, false, false, onProgress);
+        shardAnswers[i] = answer;
+        return answer;
+      },
+      reduceFn: () => {
+        /* reduce is handled below after collecting shardAnswers */
+      },
+    });
+
+    // Report per-shard errors without failing the whole run.
+    if (errors.length > 0) {
+      for (const e of errors) {
+        const msg = e.error instanceof Error ? e.error.message : String(e.error);
+        Logger.warn(`map-reduce-analyze: shard ${e.index + 1} failed: ${msg}`);
+        shardAnswers[e.index] = `[Shard ${e.index + 1} analysis failed: ${msg}]`;
+      }
+    }
+
+    // ---- Reduce phase ----
+    onProgress?.(STATUS_MESSAGES.MAP_REDUCE_REDUCING);
+    const reducePrompt = buildReducePrompt(prompt as string, shardAnswers);
+    const synthesis = await executeGeminiCLI(reducePrompt, undefined, false, false, onProgress);
+
+    const errorNote =
+      errors.length > 0
+        ? `\n\n> **Note:** ${errors.length} shard(s) encountered errors during analysis (shards: ${errors.map((e) => e.index + 1).join(', ')}). Results may be incomplete.`
+        : '';
+
+    return `${synthesis}${errorNote}`;
+  },
+};

--- a/src/utils/mapReduce.ts
+++ b/src/utils/mapReduce.ts
@@ -1,0 +1,77 @@
+/** A per-shard error captured without aborting the overall run. */
+export interface ShardError {
+  index: number;
+  error: unknown;
+}
+
+export interface MapReduceOptions<T, R, O> {
+  shards: T[];
+  mapFn: (shard: T, index: number) => Promise<R>;
+  reduceFn: (results: Array<R | undefined>, errors: ShardError[]) => Promise<O> | O;
+  concurrency: number;
+}
+
+export interface MapReduceResult<O> {
+  output: O;
+  errors: ShardError[];
+}
+
+/**
+ * Runs `mapFn` over every shard with a bounded concurrency pool, preserves
+ * result order, captures per-shard rejections without aborting other shards,
+ * then calls `reduceFn` with the ordered results array (failed shards are
+ * `undefined` at their index) and a list of captured errors.
+ */
+export async function mapReduce<T, R, O>(
+  options: MapReduceOptions<T, R, O>,
+): Promise<MapReduceResult<O>> {
+  const { shards, mapFn, reduceFn, concurrency } = options;
+
+  const results: Array<R | undefined> = new Array(shards.length).fill(undefined);
+  const errors: ShardError[] = [];
+
+  // Bounded pool: maintain at most `concurrency` in-flight promises.
+  let nextIndex = 0;
+  let inFlight = 0;
+
+  await new Promise<void>((resolve, reject) => {
+    function trySchedule(): void {
+      while (inFlight < concurrency && nextIndex < shards.length) {
+        const i = nextIndex++;
+        inFlight++;
+
+        mapFn(shards[i], i)
+          .then((result) => {
+            results[i] = result;
+          })
+          .catch((err: unknown) => {
+            errors.push({ index: i, error: err });
+          })
+          .finally(() => {
+            inFlight--;
+            if (nextIndex < shards.length || inFlight > 0) {
+              trySchedule();
+            } else {
+              resolve();
+            }
+          });
+      }
+
+      // All shards dispatched and nothing in flight — we're done.
+      if (nextIndex >= shards.length && inFlight === 0) {
+        resolve();
+      }
+    }
+
+    // Edge case: empty shard list.
+    if (shards.length === 0) {
+      resolve();
+      return;
+    }
+
+    trySchedule();
+  });
+
+  const output = await reduceFn(results, errors);
+  return { output, errors };
+}

--- a/src/utils/sharding.ts
+++ b/src/utils/sharding.ts
@@ -1,0 +1,124 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** A single shard: an ordered list of files to be analyzed together. */
+export interface Shard {
+  files: Array<{ path: string; bytes: number }>;
+}
+
+/**
+ * Greedy bin-packs `files` into shards so that each shard stays as close to
+ * `targetBytesPerShard` as possible without splitting individual files.
+ *
+ * Rules:
+ * - Empty input → []
+ * - A file that is larger than `targetBytesPerShard` on its own becomes its own shard.
+ * - `maxFilesPerShard`, when provided, caps the number of files per shard.
+ * - Input order is preserved within and across shards.
+ */
+export function planShards(
+  files: Array<{ path: string; bytes: number }>,
+  targetBytesPerShard: number,
+  maxFilesPerShard?: number,
+): Shard[] {
+  if (files.length === 0) return [];
+
+  const shards: Shard[] = [];
+  let currentShard: Shard = { files: [] };
+  let currentBytes = 0;
+
+  for (const file of files) {
+    const wouldExceedBytes = currentBytes + file.bytes > targetBytesPerShard;
+    const wouldExceedFiles =
+      maxFilesPerShard !== undefined && currentShard.files.length >= maxFilesPerShard;
+
+    // If the current shard already has files and adding this one would exceed limits,
+    // close the current shard and open a new one.
+    if (currentShard.files.length > 0 && (wouldExceedBytes || wouldExceedFiles)) {
+      shards.push(currentShard);
+      currentShard = { files: [] };
+      currentBytes = 0;
+    }
+
+    currentShard.files.push(file);
+    currentBytes += file.bytes;
+  }
+
+  if (currentShard.files.length > 0) {
+    shards.push(currentShard);
+  }
+
+  return shards;
+}
+
+/** Directories and patterns to skip when walking the workspace. */
+const DEFAULT_IGNORE_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  '.gemini-mcp',
+  '.tmptest',
+]);
+
+export interface CollectFilesOptions {
+  ignoreDirs?: Set<string>;
+}
+
+/**
+ * Recursively collects all files under `root`, skipping ignored directories,
+ * and returns their absolute paths + byte sizes.
+ *
+ * Security: `root` must resolve within `process.cwd()`.  Symlinks that escape
+ * the root are not followed (readdir uses `withFileTypes`; stat is called on
+ * the resolved entry, not the symlink target, because we just want the size).
+ */
+export function collectFiles(
+  root: string,
+  opts?: CollectFilesOptions,
+): Array<{ path: string; bytes: number }> {
+  const cwd = process.cwd();
+  const resolvedRoot = path.resolve(root);
+
+  // Confine to cwd.
+  const normalizedCwd = path.resolve(cwd);
+  const escapesRoot =
+    resolvedRoot !== normalizedCwd &&
+    !resolvedRoot.startsWith(normalizedCwd + path.sep);
+  if (escapesRoot) {
+    throw new Error(
+      `collectFiles: root "${root}" resolves to "${resolvedRoot}" which is outside the working directory "${normalizedCwd}".`,
+    );
+  }
+
+  const ignoreDirs = opts?.ignoreDirs ?? DEFAULT_IGNORE_DIRS;
+  const results: Array<{ path: string; bytes: number }> = [];
+
+  function walk(dir: string): void {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // inaccessible directory — skip silently
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (ignoreDirs.has(entry.name)) continue;
+        walk(path.join(dir, entry.name));
+      } else if (entry.isFile()) {
+        const fullPath = path.join(dir, entry.name);
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(fullPath);
+        } catch {
+          continue; // unreadable — skip
+        }
+        results.push({ path: fullPath, bytes: stat.size });
+      }
+      // Symlinks: skip (don't follow, avoids escape vectors)
+    }
+  }
+
+  walk(resolvedRoot);
+  return results;
+}

--- a/test/integration/collectFiles.test.ts
+++ b/test/integration/collectFiles.test.ts
@@ -1,0 +1,121 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { collectFiles } from '../../src/utils/sharding.js';
+
+/**
+ * Integration test for collectFiles.
+ * Creates a real temporary directory tree, calls collectFiles, and verifies
+ * the expected behaviour:
+ *   - Returns files under the root with correct sizes.
+ *   - Skips ignored directories (node_modules, .git, dist, .gemini-mcp, .tmptest).
+ *   - Confined: rejects roots that escape process.cwd().
+ */
+
+let tmpDir: string;
+
+before(() => {
+  // Create a temp dir inside process.cwd() so the confinement check passes.
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.tmptest-collectfiles-'));
+  // Nested structure:
+  //   src/
+  //     index.ts         (10 bytes)
+  //     utils/
+  //       helper.ts      (20 bytes)
+  //   node_modules/
+  //     some-pkg/
+  //       index.js       (should be ignored)
+  //   .git/
+  //     HEAD             (should be ignored)
+  //   dist/
+  //     bundle.js        (should be ignored)
+  //   .gemini-mcp/
+  //     config.json      (should be ignored)
+  //   .tmptest/
+  //     temp.ts          (should be ignored)
+
+  // Create non-ignored files
+  fs.mkdirSync(path.join(tmpDir, 'src', 'utils'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'src', 'index.ts'), '0123456789'); // 10 bytes
+  fs.writeFileSync(path.join(tmpDir, 'src', 'utils', 'helper.ts'), '01234567890123456789'); // 20 bytes
+
+  // Create ignored directories with files inside
+  fs.mkdirSync(path.join(tmpDir, 'node_modules', 'some-pkg'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'node_modules', 'some-pkg', 'index.js'), 'ignored');
+
+  fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, '.git', 'HEAD'), 'ref: refs/heads/main');
+
+  fs.mkdirSync(path.join(tmpDir, 'dist'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'dist', 'bundle.js'), 'bundled');
+
+  fs.mkdirSync(path.join(tmpDir, '.gemini-mcp'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, '.gemini-mcp', 'config.json'), '{}');
+
+  fs.mkdirSync(path.join(tmpDir, '.tmptest'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, '.tmptest', 'temp.ts'), 'temp');
+});
+
+after(() => {
+  // Clean up the temp directory.
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('collectFiles (integration)', () => {
+  test('returns only non-ignored files with correct byte sizes', () => {
+    const results = collectFiles(tmpDir);
+
+    const relPaths = results.map((f) =>
+      path.relative(tmpDir, f.path).replace(/\\/g, '/'),
+    );
+
+    assert.ok(relPaths.includes('src/index.ts'), 'should include src/index.ts');
+    assert.ok(
+      relPaths.includes('src/utils/helper.ts'),
+      'should include src/utils/helper.ts',
+    );
+    assert.equal(results.length, 2, `expected 2 files, got: ${relPaths.join(', ')}`);
+  });
+
+  test('ignored directories are not traversed', () => {
+    const results = collectFiles(tmpDir);
+    const relPaths = results.map((f) =>
+      path.relative(tmpDir, f.path).replace(/\\/g, '/'),
+    );
+
+    const ignored = ['node_modules', '.git', 'dist', '.gemini-mcp', '.tmptest'];
+    for (const dir of ignored) {
+      const leaked = relPaths.find((p) => p.startsWith(dir + '/'));
+      assert.equal(
+        leaked,
+        undefined,
+        `file from ignored dir "${dir}" should not appear: ${leaked}`,
+      );
+    }
+  });
+
+  test('byte sizes match actual file sizes', () => {
+    const results = collectFiles(tmpDir);
+
+    const indexEntry = results.find((f) => f.path.endsWith('index.ts'));
+    const helperEntry = results.find((f) => f.path.endsWith('helper.ts'));
+
+    assert.ok(indexEntry, 'index.ts entry missing');
+    assert.ok(helperEntry, 'helper.ts entry missing');
+
+    assert.equal(indexEntry!.bytes, 10, 'index.ts should be 10 bytes');
+    assert.equal(helperEntry!.bytes, 20, 'helper.ts should be 20 bytes');
+  });
+
+  test('rejects a root that escapes process.cwd()', () => {
+    // Use an absolute path that is guaranteed to be outside the project root.
+    // /etc is present on all Linux/macOS systems used in CI and is never under
+    // any reasonable project root.
+    const outsideRoot = '/etc';
+    assert.throws(
+      () => collectFiles(outsideRoot),
+      /outside the working directory/,
+    );
+  });
+});

--- a/test/unit/tools/map-reduce-analyze.test.ts
+++ b/test/unit/tools/map-reduce-analyze.test.ts
@@ -1,0 +1,69 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+// Importing the tools index registers every tool in the shared registry.
+import {
+  getToolDefinitions,
+  toolExists,
+} from '../../../src/tools/index.js';
+
+describe('MCP Tool: map-reduce-analyze registry', () => {
+  test('map-reduce-analyze is registered', () => {
+    assert.equal(toolExists('map-reduce-analyze'), true);
+  });
+
+  test('map-reduce-analyze has a valid JSON-schema definition', () => {
+    const defs = getToolDefinitions();
+    const def = defs.find((d) => d.name === 'map-reduce-analyze');
+    assert.ok(def, 'tool definition not found');
+    assert.equal(def!.inputSchema.type, 'object');
+    assert.ok(
+      typeof def!.inputSchema.properties === 'object',
+      'inputSchema must have properties',
+    );
+  });
+
+  test('map-reduce-analyze schema requires "prompt"', () => {
+    const defs = getToolDefinitions();
+    const def = defs.find((d) => d.name === 'map-reduce-analyze');
+    assert.ok(def, 'tool definition not found');
+    const required = def!.inputSchema.required as string[];
+    assert.ok(
+      required.includes('prompt'),
+      `"prompt" must be in required, got: ${JSON.stringify(required)}`,
+    );
+  });
+
+  test('map-reduce-analyze schema has optional fields: paths, concurrency, shardBytes', () => {
+    const defs = getToolDefinitions();
+    const def = defs.find((d) => d.name === 'map-reduce-analyze');
+    assert.ok(def, 'tool definition not found');
+
+    const props = def!.inputSchema.properties as Record<string, unknown>;
+    assert.ok('paths' in props, 'schema should have "paths" property');
+    assert.ok('concurrency' in props, 'schema should have "concurrency" property');
+    assert.ok('shardBytes' in props, 'schema should have "shardBytes" property');
+
+    const required = def!.inputSchema.required as string[];
+    assert.ok(!required.includes('paths'), '"paths" should be optional');
+    assert.ok(!required.includes('concurrency'), '"concurrency" should be optional');
+    assert.ok(!required.includes('shardBytes'), '"shardBytes" should be optional');
+  });
+
+  test('map-reduce-analyze rejects missing prompt via executeTool', async () => {
+    const { executeTool } = await import('../../../src/tools/index.js');
+    await assert.rejects(
+      () => executeTool('map-reduce-analyze', {}),
+      /Invalid arguments for map-reduce-analyze.*prompt/s,
+    );
+  });
+
+  test('map-reduce-analyze returns ❌ for a path escaping cwd', async () => {
+    const { executeTool } = await import('../../../src/tools/index.js');
+    const result = await executeTool('map-reduce-analyze', {
+      prompt: 'test',
+      paths: '/etc',
+    });
+    assert.match(result, /❌/);
+    assert.match(result, /outside the project directory/);
+  });
+});

--- a/test/unit/utils/mapReduce.test.ts
+++ b/test/unit/utils/mapReduce.test.ts
@@ -1,0 +1,155 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapReduce } from '../../../src/utils/mapReduce.js';
+
+describe('mapReduce', () => {
+  test('empty shards list: reduceFn receives empty arrays', async () => {
+    const { output, errors } = await mapReduce({
+      shards: [],
+      concurrency: 4,
+      mapFn: async () => 'x',
+      reduceFn: (results, errs) => ({ results, errs }),
+    });
+    assert.deepEqual(output.results, []);
+    assert.deepEqual(output.errs, []);
+    assert.equal(errors.length, 0);
+  });
+
+  test('single shard: result is returned at index 0', async () => {
+    const { output } = await mapReduce({
+      shards: ['hello'],
+      concurrency: 1,
+      mapFn: async (s) => s.toUpperCase(),
+      reduceFn: (results) => results[0],
+    });
+    assert.equal(output, 'HELLO');
+  });
+
+  test('results are aggregated in input order regardless of execution order', async () => {
+    // Map function resolves in reverse order via staggered timeouts.
+    const shards = [30, 20, 10]; // delay in ms
+    const { output } = await mapReduce({
+      shards,
+      concurrency: 3,
+      mapFn: async (delay, i) => {
+        await new Promise<void>((res) => setTimeout(res, delay));
+        return i; // return the shard index as the result
+      },
+      reduceFn: (results) => results as number[],
+    });
+    assert.deepEqual(output, [0, 1, 2]);
+  });
+
+  test('concurrency is never exceeded', async () => {
+    let inFlight = 0;
+    let maxObserved = 0;
+    const concurrency = 3;
+    const shardCount = 10;
+
+    await mapReduce({
+      shards: Array.from({ length: shardCount }, (_, i) => i),
+      concurrency,
+      mapFn: async () => {
+        inFlight++;
+        maxObserved = Math.max(maxObserved, inFlight);
+        await new Promise<void>((res) => setTimeout(res, 5));
+        inFlight--;
+        return 1;
+      },
+      reduceFn: (results) => results,
+    });
+
+    assert.ok(
+      maxObserved <= concurrency,
+      `Expected max in-flight ≤ ${concurrency}, got ${maxObserved}`,
+    );
+    // Also verify concurrency was actually utilised when possible.
+    assert.ok(
+      maxObserved >= Math.min(concurrency, shardCount),
+      `Expected concurrency ${concurrency} to be saturated`,
+    );
+  });
+
+  test('a rejecting shard is captured as an error and does not abort others', async () => {
+    const shards = [0, 1, 2, 3, 4];
+
+    const { output, errors } = await mapReduce({
+      shards,
+      concurrency: 2,
+      mapFn: async (v) => {
+        if (v === 2) throw new Error(`shard-${v}-failed`);
+        return v * 10;
+      },
+      reduceFn: (results, errs) => ({ results, errs }),
+    });
+
+    // The failing shard at index 2 should be undefined in results.
+    assert.equal(output.results[2], undefined);
+
+    // All other shards should have been processed.
+    assert.equal(output.results[0], 0);
+    assert.equal(output.results[1], 10);
+    assert.equal(output.results[3], 30);
+    assert.equal(output.results[4], 40);
+
+    // Exactly one error, for shard index 2.
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].index, 2);
+    assert.ok(errors[0].error instanceof Error);
+    assert.match((errors[0].error as Error).message, /shard-2-failed/);
+  });
+
+  test('multiple rejecting shards are all captured', async () => {
+    const shards = [0, 1, 2];
+
+    const { errors } = await mapReduce({
+      shards,
+      concurrency: 3,
+      mapFn: async (v) => {
+        throw new Error(`fail-${v}`);
+      },
+      reduceFn: (_results, errs) => errs,
+    });
+
+    assert.equal(errors.length, 3);
+    const failedIndices = errors.map((e) => e.index).sort((a, b) => a - b);
+    assert.deepEqual(failedIndices, [0, 1, 2]);
+  });
+
+  test('concurrency=1 processes shards serially', async () => {
+    const order: number[] = [];
+
+    await mapReduce({
+      shards: [0, 1, 2, 3],
+      concurrency: 1,
+      mapFn: async (v) => {
+        order.push(v);
+        return v;
+      },
+      reduceFn: (r) => r,
+    });
+
+    assert.deepEqual(order, [0, 1, 2, 3]);
+  });
+
+  test('reduceFn receives undefined at failing shard positions', async () => {
+    let capturedResults: Array<number | undefined> = [];
+
+    await mapReduce({
+      shards: [0, 1, 2],
+      concurrency: 3,
+      mapFn: async (v) => {
+        if (v === 1) throw new Error('boom');
+        return v;
+      },
+      reduceFn: (results) => {
+        capturedResults = results as Array<number | undefined>;
+        return null;
+      },
+    });
+
+    assert.equal(capturedResults[0], 0);
+    assert.equal(capturedResults[1], undefined); // failed shard
+    assert.equal(capturedResults[2], 2);
+  });
+});

--- a/test/unit/utils/sharding.test.ts
+++ b/test/unit/utils/sharding.test.ts
@@ -1,0 +1,117 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { planShards } from '../../../src/utils/sharding.js';
+
+describe('planShards', () => {
+  test('empty input returns an empty array', () => {
+    assert.deepEqual(planShards([], 1000), []);
+  });
+
+  test('single file that fits in one shard', () => {
+    const files = [{ path: 'a.ts', bytes: 500 }];
+    const shards = planShards(files, 1000);
+    assert.equal(shards.length, 1);
+    assert.deepEqual(shards[0].files, files);
+  });
+
+  test('partitions files by byte size', () => {
+    const files = [
+      { path: 'a.ts', bytes: 600 },
+      { path: 'b.ts', bytes: 600 },
+      { path: 'c.ts', bytes: 600 },
+    ];
+    // targetBytesPerShard=800 → a+b would exceed (1200>800), so each gets its own shard
+    // Actually a alone=600, adding b=1200 > 800 → shard [a], shard [b], adding c: alone=600 ok → shard [c]
+    const shards = planShards(files, 800);
+    assert.equal(shards.length, 3);
+    assert.deepEqual(shards[0].files, [files[0]]);
+    assert.deepEqual(shards[1].files, [files[1]]);
+    assert.deepEqual(shards[2].files, [files[2]]);
+  });
+
+  test('packs multiple small files into one shard when they fit', () => {
+    const files = [
+      { path: 'a.ts', bytes: 100 },
+      { path: 'b.ts', bytes: 100 },
+      { path: 'c.ts', bytes: 100 },
+    ];
+    const shards = planShards(files, 1000);
+    assert.equal(shards.length, 1);
+    assert.equal(shards[0].files.length, 3);
+  });
+
+  test('never splits a file across shards', () => {
+    const files = [
+      { path: 'small.ts', bytes: 10 },
+      { path: 'large.ts', bytes: 900 },
+      { path: 'small2.ts', bytes: 10 },
+    ];
+    // Each file must appear in exactly one shard.
+    const shards = planShards(files, 800);
+    const allFiles = shards.flatMap((s) => s.files);
+    assert.equal(allFiles.length, 3);
+    // large.ts must appear exactly once
+    const largeCount = allFiles.filter((f) => f.path === 'large.ts').length;
+    assert.equal(largeCount, 1);
+  });
+
+  test('a single oversize file becomes its own shard', () => {
+    const files = [{ path: 'giant.ts', bytes: 5_000_000 }];
+    const shards = planShards(files, 800_000);
+    assert.equal(shards.length, 1);
+    assert.deepEqual(shards[0].files, files);
+  });
+
+  test('multiple oversize files each get their own shard', () => {
+    const files = [
+      { path: 'giant1.ts', bytes: 2_000_000 },
+      { path: 'giant2.ts', bytes: 3_000_000 },
+    ];
+    const shards = planShards(files, 800_000);
+    assert.equal(shards.length, 2);
+    assert.equal(shards[0].files[0].path, 'giant1.ts');
+    assert.equal(shards[1].files[0].path, 'giant2.ts');
+  });
+
+  test('stable order: shard file order matches input order', () => {
+    const files = [
+      { path: 'z.ts', bytes: 100 },
+      { path: 'a.ts', bytes: 100 },
+      { path: 'm.ts', bytes: 100 },
+    ];
+    const shards = planShards(files, 1000);
+    const allFiles = shards.flatMap((s) => s.files);
+    assert.deepEqual(
+      allFiles.map((f) => f.path),
+      ['z.ts', 'a.ts', 'm.ts'],
+    );
+  });
+
+  test('maxFilesPerShard caps files per shard', () => {
+    const files = [
+      { path: 'a.ts', bytes: 10 },
+      { path: 'b.ts', bytes: 10 },
+      { path: 'c.ts', bytes: 10 },
+      { path: 'd.ts', bytes: 10 },
+    ];
+    // Large target so bytes won't trigger splits — only file cap should.
+    const shards = planShards(files, 100_000, 2);
+    assert.equal(shards.length, 2);
+    assert.equal(shards[0].files.length, 2);
+    assert.equal(shards[1].files.length, 2);
+  });
+
+  test('bin-packs greedily: fills current shard before opening a new one', () => {
+    const files = [
+      { path: 'a.ts', bytes: 300 },
+      { path: 'b.ts', bytes: 300 },
+      { path: 'c.ts', bytes: 300 },
+      { path: 'd.ts', bytes: 300 },
+    ];
+    // 300+300=600 ≤ 700; 600+300=900 > 700 → close; new shard: 300+300=600 ≤ 700
+    const shards = planShards(files, 700);
+    assert.equal(shards.length, 2);
+    assert.equal(shards[0].files.length, 2);
+    assert.equal(shards[1].files.length, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `map-reduce-analyze`, a tool that enables whole-repository analysis for codebases that exceed a single Gemini context. The workspace is greedy bin-packed into byte-bounded shards; each shard is analyzed in parallel through a bounded concurrency pool; a final reduce call synthesizes the results into one answer.

## Key design points

- `sharding.ts` and `mapReduce.ts` are pure utilities with no I/O or Gemini coupling — fully unit-testable with fake async functions (the tests assert the concurrency cap is never exceeded, order is preserved, and a failing shard is captured without aborting the run).
- All file paths are confined to `process.cwd()` (the same guard pattern used elsewhere after CVE-2026-0755); the file walk skips symlinks and a default ignore set (`node_modules`, `.git`, `dist`, `.gemini-mcp`).
- A hard cap of 50 shards prevents runaway API cost; the error message guides users to raise `shardBytes` when triggered.
- Default concurrency (4) is read from `GEMINI_MCP_MAP_CONCURRENCY` and can be overridden per call (clamped to 1–10).

## Verification

- `npx tsc --noEmit` — clean
- `node scripts/run-tests.mjs unit integration` — 85 pass / 0 fail

## Notes

- Opt-in: a new tool; no existing behavior changes.
- Per-shard `@file` references also pass through the existing `assertSafeFileReferences` guard (defense in depth).