### PR TITLE
feat: transactional applier for structured multi-file edits

### DIFF
--- a/docs/usage/apply-edits.md
+++ b/docs/usage/apply-edits.md
@@ -1,0 +1,108 @@
+# apply-edits
+
+Apply a multi-file changeMode edit set transactionally — validate every OLD block, preview the changes as a unified diff, then write all files at once with automatic rollback on failure.
+
+## Overview
+
+When you ask Gemini to refactor a large codebase using `ask-gemini` with `changeMode:true`, the response contains one or more OLD/NEW edit blocks. `apply-edits` takes that raw text and applies every edit atomically: either all files are updated or none are (if any write fails, already-written files are restored from their original content).
+
+## Workflow
+
+`apply-edits` is intentionally a two-step process to prevent accidental destructive writes.
+
+### Step 1 — Preview (dry run, default)
+
+Call `apply-edits` with only the `edits` parameter (or with `dryRun:true`). No files are written. The tool:
+
+1. Parses all OLD/NEW blocks from the changeMode text.
+2. Reads each target file and verifies every OLD block appears **exactly once** (zero or multiple occurrences are reported as errors).
+3. Applies all replacements in memory and renders a unified diff preview.
+
+```
+apply-edits(
+  edits: "<paste the changeMode output from ask-gemini here>"
+)
+```
+
+If any OLD block cannot be located or is ambiguous, the tool returns an `❌` error listing every problem. No files are modified.
+
+### Step 2 — Apply
+
+Once you are satisfied with the diff preview, re-call with `dryRun:false` and `confirm:true`:
+
+```
+apply-edits(
+  edits: "<same changeMode text>",
+  dryRun: false,
+  confirm: true
+)
+```
+
+All files are written in a single pass. If a write fails partway through (e.g., a permissions error), all previously written files are restored to their original content and the error is surfaced with context.
+
+## Parameters
+
+| Parameter | Type    | Default | Description |
+|-----------|---------|---------|-------------|
+| `edits`   | string  | —       | **Required.** The raw changeMode OLD/NEW text produced by `ask-gemini` with `changeMode:true`. |
+| `dryRun`  | boolean | `true`  | When true, only validate and preview — no files are written. |
+| `confirm` | boolean | `false` | Safety gate. Must be `true` (together with `dryRun:false`) to write files. |
+
+## Producing edits with ask-gemini
+
+Run `ask-gemini` with `changeMode:true` to obtain structured edit blocks:
+
+```
+ask-gemini(
+  prompt: "Rename all occurrences of UserService to AccountService across @src/",
+  changeMode: true
+)
+```
+
+The response will contain blocks like:
+
+```
+**FILE: src/services/user.service.ts:1**
+` `` `
+OLD:
+export class UserService {
+NEW:
+export class AccountService {
+` `` `
+```
+
+Copy the entire response and pass it as the `edits` parameter to `apply-edits`.
+
+## Error conditions
+
+| Condition | Behaviour |
+|-----------|-----------|
+| No OLD/NEW blocks found in `edits` | Returns `❌` immediately; nothing is read or written. |
+| OLD block not found in file | Returns `❌` with the filename and the first line of the missing OLD block. |
+| OLD block found more than once | Returns `❌` flagging the ambiguous match; add more surrounding context lines to the OLD block to make it unique. |
+| Path escapes project root (`../`, absolute, `~`) | Returns `❌`; all paths must be relative to the project root. |
+| Write fails partway through | Rolls back already-written files, then returns `❌` with full context. |
+
+## Security
+
+All target file paths are resolved relative to the current working directory and confined to it. Absolute paths, `~`-prefixed paths, and `..`-escaping paths are rejected before any file is read or written.
+
+## Example session
+
+```
+# 1. Generate edits
+ask-gemini(
+  prompt: "Replace console.log with Logger.log across @src/",
+  changeMode: true
+)
+
+# 2. Preview (dry run)
+apply-edits(edits: "<output from above>")
+
+# 3. Review the diff, then apply
+apply-edits(
+  edits: "<same output>",
+  dryRun: false,
+  confirm: true
+)
+```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,8 @@ export const ERROR_MESSAGES = {
   QUOTA_EXCEEDED_SHORT: "⚠️ Gemini 2.5 Pro daily quota exceeded. Please retry with model: 'gemini-2.5-flash'",
   TOOL_NOT_FOUND: "not found in registry",
   NO_PROMPT_PROVIDED: "Please provide a prompt for analysis. Use @ syntax to include files (e.g., '@largefile.js explain what this does') or ask general questions",
+  APPLY_EDITS_NO_EDITS: "No changeMode OLD/NEW edits found in the provided text. Ensure the input uses the changeMode format produced by ask-gemini with changeMode:true.",
+  APPLY_EDITS_VALIDATION_FAILED: "Edit validation failed — no files were written.",
 } as const;
 
 // Status messages
@@ -22,6 +24,10 @@ export const STATUS_MESSAGES = {
   PROCESSING_START: "🔍 Starting analysis (may take 5-15 minutes for large codebases)",
   PROCESSING_CONTINUE: "⏳ Still processing... Gemini is working on your request",
   PROCESSING_COMPLETE: "✅ Analysis completed successfully",
+  // apply-edits messages
+  APPLY_EDITS_DRY_RUN: "Dry-run preview (no files written). Re-call with dryRun:false, confirm:true to apply.",
+  APPLY_EDITS_CONFIRM_REQUIRED: "Set confirm:true to apply the changes shown above.",
+  APPLY_EDITS_SUCCESS: "All changes applied successfully.",
 } as const;
 
 // Models

--- a/src/tools/apply-edits.tool.ts
+++ b/src/tools/apply-edits.tool.ts
@@ -1,0 +1,168 @@
+/**
+ * apply-edits tool — transactional applier for structured changeMode edit sets.
+ *
+ * Accepts the raw OLD/NEW text produced by ask-gemini with changeMode:true,
+ * validates every edit, previews changes as a diff, then writes all-or-nothing
+ * with automatic rollback on partial failure.
+ *
+ * Two-phase workflow:
+ *   1. dryRun:true  (default) — validate and show diff, no files written.
+ *   2. dryRun:false, confirm:true — apply; all files written or none.
+ */
+
+import { z } from 'zod';
+import * as fs from 'fs';
+import * as path from 'path';
+import { UnifiedTool } from './registry.js';
+import { parseChangeModeOutput } from '../utils/changeModeParser.js';
+import {
+  planApply,
+  renderDiff,
+  commitPlan,
+} from '../utils/changeModeApplier.js';
+import { Logger } from '../utils/logger.js';
+import {
+  ERROR_MESSAGES,
+  STATUS_MESSAGES,
+} from '../constants.js';
+
+// ---------------------------------------------------------------------------
+// Zod schema
+// ---------------------------------------------------------------------------
+
+const applyEditsSchema = z.object({
+  edits: z
+    .string()
+    .min(1)
+    .describe(
+      'The raw changeMode OLD/NEW edit text produced by ask-gemini with changeMode:true. ' +
+      'Must contain one or more **FILE: path:line** blocks.'
+    ),
+  dryRun: z
+    .boolean()
+    .default(true)
+    .describe(
+      'When true (default) only validate and preview the diff — no files are written. ' +
+      'Set to false together with confirm:true to apply.'
+    ),
+  confirm: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Safety gate: must be set to true (together with dryRun:false) to actually write files. ' +
+      'Prevents accidental destructive writes.'
+    ),
+});
+
+// ---------------------------------------------------------------------------
+// Tool definition
+// ---------------------------------------------------------------------------
+
+export const applyEditsTool: UnifiedTool = {
+  name: 'apply-edits',
+  description:
+    'Applies a changeMode OLD/NEW edit set transactionally. ' +
+    'Validates every OLD block (must appear exactly once), renders a diff preview, ' +
+    'then writes all files atomically with rollback on failure. ' +
+    'Use dryRun:true (default) to preview, then dryRun:false + confirm:true to apply.',
+  zodSchema: applyEditsSchema,
+  category: 'utility',
+
+  execute: async (args): Promise<string> => {
+    const { edits, dryRun, confirm } = args as {
+      edits: string;
+      dryRun: boolean;
+      confirm: boolean;
+    };
+
+    Logger.debug(`apply-edits: dryRun=${dryRun} confirm=${confirm}`);
+
+    // ------------------------------------------------------------------
+    // 1. Parse changeMode text → edit objects
+    // ------------------------------------------------------------------
+    const parsed = parseChangeModeOutput(edits);
+
+    if (parsed.length === 0) {
+      return `❌ ${ERROR_MESSAGES.APPLY_EDITS_NO_EDITS}`;
+    }
+
+    Logger.debug(`apply-edits: parsed ${parsed.length} edit(s)`);
+
+    // ------------------------------------------------------------------
+    // 2. Plan (validate + build in-memory diffs); IO is injected here
+    // ------------------------------------------------------------------
+    const root = process.cwd();
+
+    const plan = planApply(parsed, {
+      root,
+      readFile: (absPath: string) =>
+        fs.readFileSync(absPath, 'utf8'),
+    });
+
+    // ------------------------------------------------------------------
+    // 3. If there are validation errors, surface them immediately
+    // ------------------------------------------------------------------
+    if (plan.errors.length > 0) {
+      const errorList = plan.errors
+        .map((e, i) => `  ${i + 1}. ${e}`)
+        .join('\n');
+      return (
+        `❌ ${ERROR_MESSAGES.APPLY_EDITS_VALIDATION_FAILED}\n\n` +
+        `**Errors (${plan.errors.length}):**\n${errorList}`
+      );
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Build diff preview (used in both dry-run and pre-apply output)
+    // ------------------------------------------------------------------
+    const diff = renderDiff(plan);
+
+    const totalEdits = plan.files.reduce((n, f) => n + f.editCount, 0);
+    const fileCount = plan.files.length;
+    const fileSummary = plan.files
+      .map(f => `  - ${path.relative(root, f.path)} (${f.editCount} edit${f.editCount !== 1 ? 's' : ''})`)
+      .join('\n');
+
+    const summaryHeader =
+      `**${totalEdits} edit${totalEdits !== 1 ? 's' : ''} across ` +
+      `${fileCount} file${fileCount !== 1 ? 's' : ''}:**\n${fileSummary}`;
+
+    // ------------------------------------------------------------------
+    // 5. Dry-run: return diff without writing
+    // ------------------------------------------------------------------
+    if (dryRun || !confirm) {
+      const instruction =
+        dryRun
+          ? STATUS_MESSAGES.APPLY_EDITS_DRY_RUN
+          : STATUS_MESSAGES.APPLY_EDITS_CONFIRM_REQUIRED;
+
+      return (
+        `## apply-edits preview\n\n` +
+        `${summaryHeader}\n\n` +
+        `\`\`\`diff\n${diff}\n\`\`\`\n\n` +
+        `> ${instruction}`
+      );
+    }
+
+    // ------------------------------------------------------------------
+    // 6. Commit: write all files or roll back
+    // ------------------------------------------------------------------
+    try {
+      commitPlan(plan, {
+        writeFile: (absPath: string, content: string) =>
+          fs.writeFileSync(absPath, content, 'utf8'),
+      });
+    } catch (err) {
+      return `❌ Apply failed (rollback attempted):\n\n${(err as Error).message}`;
+    }
+
+    Logger.debug(`apply-edits: wrote ${fileCount} file(s)`);
+
+    return (
+      `## apply-edits complete\n\n` +
+      `${summaryHeader}\n\n` +
+      `\`\`\`diff\n${diff}\n\`\`\`\n\n` +
+      `> ${STATUS_MESSAGES.APPLY_EDITS_SUCCESS}`
+    );
+  },
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,13 +5,15 @@ import { pingTool, helpTool } from './simple-tools.js';
 import { brainstormTool } from './brainstorm.tool.js';
 import { fetchChunkTool } from './fetch-chunk.tool.js';
 import { timeoutTestTool } from './timeout-test.tool.js';
+import { applyEditsTool } from './apply-edits.tool.js';
 
 toolRegistry.push(
   askGeminiTool,
   pingTool,
   helpTool,
   brainstormTool,
-  fetchChunkTool
+  fetchChunkTool,
+  applyEditsTool
 );
 
 // Only register test-only tools when explicitly enabled (e.g. judge/e2e test suite)

--- a/src/utils/changeModeApplier.ts
+++ b/src/utils/changeModeApplier.ts
@@ -1,0 +1,398 @@
+/**
+ * Transactional applier for structured (changeMode) edit sets.
+ *
+ * All IO is injected so the module stays pure and fully testable without
+ * touching the real filesystem.  The execute() in apply-edits.tool.ts wires in
+ * the real fs calls.
+ */
+
+import * as path from 'path';
+import { type ChangeModeEdit } from './changeModeParser.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface FilePlan {
+  /** Absolute, root-confined path to the target file. */
+  path: string;
+  originalContent: string;
+  newContent: string;
+  /** Number of edits applied to this file. */
+  editCount: number;
+}
+
+export interface ApplyPlan {
+  files: FilePlan[];
+  /** Validation/confinement errors — if non-empty, nothing has been (or will be) written. */
+  errors: string[];
+}
+
+export interface PlanApplyOptions {
+  readFile: (absPath: string) => string;
+  /** The root directory.  All edit filenames must resolve inside it. */
+  root: string;
+}
+
+export interface CommitPlanOptions {
+  writeFile: (absPath: string, content: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Path confinement
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves `filename` relative to `root` and asserts it stays inside `root`.
+ * Rejects absolute paths, `~`-prefixed paths, and `..`-escaping paths.
+ *
+ * Throws with a descriptive message on violation (same policy as
+ * assertSafeFileReferences in geminiExecutor.ts).
+ */
+function resolveConfined(filename: string, root: string): string {
+  if (path.isAbsolute(filename)) {
+    throw new Error(
+      `Refusing absolute path in edit filename: "${filename}". ` +
+      `All paths must be relative to the project root.`
+    );
+  }
+  if (filename.startsWith('~')) {
+    throw new Error(
+      `Refusing home-directory path in edit filename: "${filename}". ` +
+      `All paths must be relative to the project root.`
+    );
+  }
+
+  const normalizedRoot = path.resolve(root);
+  const resolved = path.resolve(normalizedRoot, filename);
+
+  const escapesRoot =
+    resolved !== normalizedRoot &&
+    !resolved.startsWith(normalizedRoot + path.sep);
+
+  if (escapesRoot) {
+    throw new Error(
+      `Refusing path that escapes project root: "${filename}" → "${resolved}". ` +
+      `All paths must remain within ${normalizedRoot}.`
+    );
+  }
+
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// planApply
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates every edit in `edits` and builds an in-memory apply plan.
+ *
+ * Each edit's `oldCode` is located inside the current file content and must
+ * occur EXACTLY ONCE.  If it is absent or ambiguous the edit is recorded as
+ * an error and planning continues (so all problems surface in one pass).
+ *
+ * Returns `{ files, errors }`.  When `errors` is non-empty the caller MUST
+ * NOT call `commitPlan`.
+ */
+export function planApply(
+  edits: ChangeModeEdit[],
+  opts: PlanApplyOptions
+): ApplyPlan {
+  const { readFile, root } = opts;
+  const errors: string[] = [];
+
+  // Group edits by resolved absolute path so per-file content is read once and
+  // edits are applied in order.
+  const fileEdits = new Map<
+    string,
+    { filename: string; edit: ChangeModeEdit }[]
+  >();
+
+  for (const edit of edits) {
+    let absPath: string;
+    try {
+      absPath = resolveConfined(edit.filename, root);
+    } catch (err) {
+      errors.push((err as Error).message);
+      continue;
+    }
+    const bucket = fileEdits.get(absPath) ?? [];
+    bucket.push({ filename: edit.filename, edit });
+    fileEdits.set(absPath, bucket);
+  }
+
+  const filePlans: FilePlan[] = [];
+
+  for (const [absPath, entries] of fileEdits) {
+    let originalContent: string;
+    try {
+      originalContent = readFile(absPath);
+    } catch (err) {
+      errors.push(
+        `Cannot read "${entries[0].filename}": ${(err as Error).message}`
+      );
+      continue;
+    }
+
+    let currentContent = originalContent;
+    let fileErrors = 0;
+
+    for (const { filename, edit } of entries) {
+      const { oldCode, newCode } = edit;
+
+      // Count occurrences of oldCode in the current (already-partially-edited) content.
+      const occurrences = countOccurrences(currentContent, oldCode);
+
+      if (occurrences === 0) {
+        errors.push(
+          `Edit not found in "${filename}": ` +
+          `OLD block starting with ${JSON.stringify(firstLine(oldCode))} was not found.`
+        );
+        fileErrors++;
+        continue;
+      }
+
+      if (occurrences > 1) {
+        errors.push(
+          `Ambiguous edit in "${filename}": ` +
+          `OLD block starting with ${JSON.stringify(firstLine(oldCode))} ` +
+          `matches ${occurrences} locations. ` +
+          `Add more surrounding context to make it unique.`
+        );
+        fileErrors++;
+        continue;
+      }
+
+      // Exactly one occurrence — apply in-memory.
+      currentContent = currentContent.replace(oldCode, () => newCode);
+    }
+
+    if (fileErrors === 0) {
+      filePlans.push({
+        path: absPath,
+        originalContent,
+        newContent: currentContent,
+        editCount: entries.length,
+      });
+    }
+  }
+
+  return { files: filePlans, errors };
+}
+
+// ---------------------------------------------------------------------------
+// renderDiff
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a unified-diff-style preview of the plan.  No external deps — uses
+ * a simple line-based algorithm with `---`/`+++` headers and `+`/`-` prefixes.
+ */
+export function renderDiff(plan: ApplyPlan): string {
+  if (plan.files.length === 0) {
+    return '(no changes)';
+  }
+
+  const parts: string[] = [];
+
+  for (const file of plan.files) {
+    parts.push(`--- ${file.path}`);
+    parts.push(`+++ ${file.path}`);
+
+    const oldLines = file.originalContent.split('\n');
+    const newLines = file.newContent.split('\n');
+
+    // Compute a simple diff: find changed regions with a line-by-line scan.
+    const hunks = computeHunks(oldLines, newLines);
+    for (const hunk of hunks) {
+      parts.push(hunk);
+    }
+  }
+
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// commitPlan
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes every file in the plan.  Requires `plan.errors` to be empty.
+ *
+ * If a write throws partway through, all already-written files are restored
+ * to their `originalContent` before re-throwing.
+ */
+export function commitPlan(plan: ApplyPlan, opts: CommitPlanOptions): void {
+  if (plan.errors.length > 0) {
+    throw new Error(
+      `commitPlan called with a plan that has errors:\n${plan.errors.join('\n')}`
+    );
+  }
+
+  const { writeFile } = opts;
+  const written: FilePlan[] = [];
+
+  for (const file of plan.files) {
+    try {
+      writeFile(file.path, file.newContent);
+      written.push(file);
+    } catch (writeErr) {
+      // Rollback all previously written files.
+      const rollbackErrors: string[] = [];
+      for (const prev of written) {
+        try {
+          writeFile(prev.path, prev.originalContent);
+        } catch (rollbackErr) {
+          rollbackErrors.push(
+            `Failed to restore "${prev.path}": ${(rollbackErr as Error).message}`
+          );
+        }
+      }
+
+      const base = `Write failed for "${file.path}": ${(writeErr as Error).message}`;
+      const suffix =
+        rollbackErrors.length > 0
+          ? `\nAdditional rollback failures:\n${rollbackErrors.join('\n')}`
+          : `\n${written.length} previously written file(s) restored to original content.`;
+
+      throw new Error(base + suffix);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+/** Return the first line of a potentially multi-line string. */
+function firstLine(s: string): string {
+  const idx = s.indexOf('\n');
+  return idx === -1 ? s : s.slice(0, idx);
+}
+
+// ---------------------------------------------------------------------------
+// Diff internals
+// ---------------------------------------------------------------------------
+
+interface DiffOp {
+  type: 'equal' | 'add' | 'remove';
+  line: string;
+}
+
+/**
+ * Iterative O(n·m) LCS-based line diff.  No recursion, no stack overflow.
+ * Produces a minimal edit script using the standard DP table approach.
+ */
+function diffLines(a: string[], b: string[]): DiffOp[] {
+  const m = a.length;
+  const n = b.length;
+
+  // Build LCS length table.
+  // dp[i][j] = LCS length of a[0..i-1] vs b[0..j-1]
+  const dp: number[][] = [];
+  for (let i = 0; i <= m; i++) {
+    dp[i] = new Array(n + 1).fill(0);
+  }
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Back-track to build the edit sequence.
+  const ops: DiffOp[] = [];
+  let i = m;
+  let j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      ops.push({ type: 'equal', line: a[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.push({ type: 'add', line: b[j - 1] });
+      j--;
+    } else {
+      ops.push({ type: 'remove', line: a[i - 1] });
+      i--;
+    }
+  }
+  ops.reverse();
+  return ops;
+}
+
+/**
+ * Produce unified-diff hunk strings from two line arrays.
+ * Uses a simple context-window approach after building the full edit sequence.
+ */
+function computeHunks(oldLines: string[], newLines: string[]): string[] {
+  const CONTEXT = 3;
+  const ops = diffLines(oldLines, newLines);
+
+  if (ops.every(o => o.type === 'equal')) return [];
+
+  const result: string[] = [];
+
+  // Find changed op indices.
+  const changedAt = ops
+    .map((o, idx) => ({ o, idx }))
+    .filter(x => x.o.type !== 'equal')
+    .map(x => x.idx);
+
+  if (changedAt.length === 0) return [];
+
+  // Merge nearby changed regions into hunks (within 2*CONTEXT of each other).
+  const regions: Array<{ lo: number; hi: number }> = [];
+  let lo = Math.max(0, changedAt[0] - CONTEXT);
+  let hi = Math.min(ops.length - 1, changedAt[0] + CONTEXT);
+
+  for (let k = 1; k < changedAt.length; k++) {
+    const next = changedAt[k];
+    const nextHi = Math.min(ops.length - 1, next + CONTEXT);
+    if (next - CONTEXT <= hi + 1) {
+      hi = nextHi;
+    } else {
+      regions.push({ lo, hi });
+      lo = Math.max(0, next - CONTEXT);
+      hi = nextHi;
+    }
+  }
+  regions.push({ lo, hi });
+
+  // Compute line numbers and emit each region as a hunk.
+  for (const region of regions) {
+    const hunkOps = ops.slice(region.lo, region.hi + 1);
+
+    // Line numbers: count non-add ops before region.lo for old; non-remove for new.
+    const oldLineNum =
+      ops.slice(0, region.lo).filter(o => o.type !== 'add').length + 1;
+    const newLineNum =
+      ops.slice(0, region.lo).filter(o => o.type !== 'remove').length + 1;
+    const oldCount = hunkOps.filter(o => o.type !== 'add').length;
+    const newCount = hunkOps.filter(o => o.type !== 'remove').length;
+
+    result.push(`@@ -${oldLineNum},${oldCount} +${newLineNum},${newCount} @@`);
+    for (const op of hunkOps) {
+      if (op.type === 'equal') result.push(` ${op.line}`);
+      else if (op.type === 'remove') result.push(`-${op.line}`);
+      else result.push(`+${op.line}`);
+    }
+  }
+
+  return result;
+}

--- a/test/unit/tools/applyEdits.test.ts
+++ b/test/unit/tools/applyEdits.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for the apply-edits tool.
+ *
+ * The dryRun / confirm / commit flow is tested by calling the applier's pure
+ * functions directly with injected IO (no real filesystem, no process.chdir
+ * races with concurrent subtests).  Registry and schema shape tests use the
+ * real tool definitions.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Access the pure applier functions directly for deterministic testing.
+import {
+  planApply,
+  renderDiff,
+  commitPlan,
+} from '../../../src/utils/changeModeApplier.js';
+import { parseChangeModeOutput } from '../../../src/utils/changeModeParser.js';
+
+// Import the tool for registry/schema tests.
+import { applyEditsTool } from '../../../src/tools/apply-edits.tool.js';
+import {
+  getToolDefinitions,
+  toolExists,
+} from '../../../src/tools/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FENCE = '```';
+
+function block(file: string, line: number, oldCode: string, newCode: string): string {
+  return [`**FILE: ${file}:${line}**`, FENCE, 'OLD:', oldCode, 'NEW:', newCode, FENCE].join('\n');
+}
+
+/** Create a real temp directory, write files, run fn, then clean up. */
+function withTempDir(
+  files: Record<string, string>,
+  fn: (dir: string) => void
+): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'apply-tool-test-'));
+  try {
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content, 'utf8');
+    }
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// dryRun flow (pure injection — no process.chdir races)
+// ---------------------------------------------------------------------------
+
+describe('MCP Tool: apply-edits dryRun', () => {
+  test('dryRun plan shows diff preview and does not write files', () => {
+    withTempDir({ 'hello.ts': 'const x = 1;\n' }, dir => {
+      const editText = block('hello.ts', 1, 'const x = 1;', 'const x = 42;');
+      const parsed = parseChangeModeOutput(editText);
+      assert.equal(parsed.length, 1);
+
+      const plan = planApply(parsed, {
+        root: dir,
+        readFile: (p: string) => fs.readFileSync(p, 'utf8'),
+      });
+      assert.equal(plan.errors.length, 0, `plan errors: ${plan.errors.join('; ')}`);
+
+      const diff = renderDiff(plan);
+      assert.ok(diff.includes('diff') || diff.includes('---') || diff.includes('-const x'),
+        `expected diff markers in:\n${diff}`);
+      assert.ok(diff.includes('-const x = 1;'), 'expected removal line');
+      assert.ok(diff.includes('+const x = 42;'), 'expected addition line');
+
+      // No writes during dry-run: file must remain unchanged.
+      const content = fs.readFileSync(path.join(dir, 'hello.ts'), 'utf8');
+      assert.equal(content, 'const x = 1;\n', 'file must remain unchanged in dry run');
+    });
+  });
+
+  test('confirm:false (dryRun or not) never calls writeFile', () => {
+    let writeCount = 0;
+    withTempDir({ 'hello.ts': 'const x = 1;\n' }, dir => {
+      const editText = block('hello.ts', 1, 'const x = 1;', 'const x = 42;');
+      const parsed = parseChangeModeOutput(editText);
+      const plan = planApply(parsed, {
+        root: dir,
+        readFile: (p: string) => fs.readFileSync(p, 'utf8'),
+      });
+      assert.equal(plan.errors.length, 0);
+
+      // Simulate the "dryRun || !confirm" branch: renderDiff but no commitPlan.
+      renderDiff(plan);
+      // writeCount stays 0 because we never called commitPlan.
+    });
+    assert.equal(writeCount, 0, 'no writes should occur in dry-run mode');
+  });
+
+  test('dryRun:false + confirm:true commits the plan and writes files', () => {
+    withTempDir({ 'hello.ts': 'const x = 1;\n' }, dir => {
+      const editText = block('hello.ts', 1, 'const x = 1;', 'const x = 42;');
+      const parsed = parseChangeModeOutput(editText);
+      const plan = planApply(parsed, {
+        root: dir,
+        readFile: (p: string) => fs.readFileSync(p, 'utf8'),
+      });
+      assert.equal(plan.errors.length, 0);
+
+      // commitPlan writes files.
+      commitPlan(plan, {
+        writeFile: (p: string, c: string) => fs.writeFileSync(p, c, 'utf8'),
+      });
+
+      const content = fs.readFileSync(path.join(dir, 'hello.ts'), 'utf8');
+      assert.ok(content.includes('const x = 42;'), 'file should have been updated');
+    });
+  });
+
+  test('execute with dryRun:true returns preview string without writing (real fs, absolute paths)', async () => {
+    // Use a directory we know exists and whose abs path we can embed in the edit text.
+    withTempDir({ 'hello.ts': 'const x = 1;\n' }, dir => {
+      // The test is async-within-sync; we run the applier synchronously via
+      // the pure API to sidestep process.chdir races in the runner.
+      const editText = block('hello.ts', 1, 'const x = 1;', 'const x = 99;');
+      const parsed = parseChangeModeOutput(editText);
+      const plan = planApply(parsed, {
+        root: dir,
+        readFile: (p: string) => fs.readFileSync(p, 'utf8'),
+      });
+      const diff = renderDiff(plan);
+      assert.ok(diff.includes('+const x = 99;'), 'diff must contain the new value');
+      assert.equal(plan.errors.length, 0);
+
+      // File unchanged — no commitPlan called.
+      const content = fs.readFileSync(path.join(dir, 'hello.ts'), 'utf8');
+      assert.equal(content, 'const x = 1;\n');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling (via pure planApply)
+// ---------------------------------------------------------------------------
+
+describe('MCP Tool: apply-edits error handling', () => {
+  test('returns errors when no edits found in input', () => {
+    // Zero parsed edits → planApply returns empty files, no errors from planApply
+    // but the tool would return ❌ with APPLY_EDITS_NO_EDITS.
+    const parsed = parseChangeModeOutput('no edits here at all');
+    assert.equal(parsed.length, 0, 'expected no edits parsed');
+  });
+
+  test('OLD block not found → planApply records "not found" error', () => {
+    withTempDir({ 'src/a.ts': 'const x = 1;\n' }, dir => {
+      const editText = block('src/a.ts', 1, 'DOES_NOT_EXIST', 'replacement');
+      const parsed = parseChangeModeOutput(editText);
+      const plan = planApply(parsed, {
+        root: dir,
+        readFile: (p: string) => fs.readFileSync(p, 'utf8'),
+      });
+      assert.ok(plan.errors.length >= 1, 'expected at least one error');
+      assert.ok(
+        plan.errors.some(e => /not found/i.test(e)),
+        `expected "not found" error; got: ${plan.errors.join('; ')}`
+      );
+    });
+  });
+
+  test('OLD block ambiguous → planApply records "ambiguous" error', () => {
+    withTempDir({ 'src/a.ts': 'foo\nfoo\n' }, dir => {
+      const editText = block('src/a.ts', 1, 'foo', 'bar');
+      const parsed = parseChangeModeOutput(editText);
+      const plan = planApply(parsed, {
+        root: dir,
+        readFile: (p: string) => fs.readFileSync(p, 'utf8'),
+      });
+      assert.ok(plan.errors.length >= 1);
+      assert.ok(
+        plan.errors.some(e => /ambiguous/i.test(e)),
+        `expected "ambiguous" error; got: ${plan.errors.join('; ')}`
+      );
+    });
+  });
+
+  test('tool execute returns ❌ when no edits parsed', async () => {
+    const result = await applyEditsTool.execute({
+      edits: 'no edits here at all',
+      dryRun: true,
+      confirm: false,
+    });
+    assert.ok(result.startsWith('❌'), `expected ❌ prefix; got: ${result.slice(0, 60)}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry tests
+// ---------------------------------------------------------------------------
+
+describe('MCP Registry: apply-edits registration', () => {
+  test('apply-edits is registered in the tool registry', () => {
+    assert.equal(toolExists('apply-edits'), true);
+  });
+
+  test('apply-edits JSON schema requires the edits field', () => {
+    const defs = getToolDefinitions();
+    const def = defs.find(d => d.name === 'apply-edits');
+    assert.ok(def, 'apply-edits tool not found in definitions');
+    assert.ok(
+      (def!.inputSchema.required as string[]).includes('edits'),
+      'schema should require "edits"'
+    );
+  });
+
+  test('apply-edits schema has dryRun and confirm as optional boolean fields', () => {
+    const defs = getToolDefinitions();
+    const def = defs.find(d => d.name === 'apply-edits')!;
+    const props = def.inputSchema.properties as Record<string, any>;
+    assert.ok(props.dryRun, 'dryRun should be a schema property');
+    assert.ok(props.confirm, 'confirm should be a schema property');
+    // dryRun and confirm should NOT be in required (they have defaults).
+    assert.ok(
+      !(def.inputSchema.required as string[]).includes('dryRun'),
+      'dryRun should not be required'
+    );
+    assert.ok(
+      !(def.inputSchema.required as string[]).includes('confirm'),
+      'confirm should not be required'
+    );
+  });
+
+  test('apply-edits category is utility', () => {
+    assert.equal(applyEditsTool.category, 'utility');
+  });
+});

--- a/test/unit/utils/changeModeApplier.test.ts
+++ b/test/unit/utils/changeModeApplier.test.ts
@@ -1,0 +1,289 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  planApply,
+  renderDiff,
+  commitPlan,
+  type ApplyPlan,
+} from '../../../src/utils/changeModeApplier.js';
+import { type ChangeModeEdit } from '../../../src/utils/changeModeParser.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function edit(filename: string, oldCode: string, newCode: string): ChangeModeEdit {
+  return {
+    filename,
+    oldStartLine: 1,
+    oldEndLine: 1,
+    oldCode,
+    newStartLine: 1,
+    newEndLine: 1,
+    newCode,
+  };
+}
+
+function makeReadFile(files: Record<string, string>) {
+  return (absPath: string): string => {
+    const content = files[absPath];
+    if (content === undefined) throw new Error(`File not found: ${absPath}`);
+    return content;
+  };
+}
+
+function rootFor(filename: string): string {
+  // Returns the directory portion so the file path is resolvable.
+  return path.dirname(path.resolve('/', filename));
+}
+
+/** Create a real temp directory, write files, run fn, then clean up. */
+function withTempDir(
+  files: Record<string, string>,
+  fn: (dir: string) => void
+): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'applier-test-'));
+  try {
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content, 'utf8');
+    }
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// planApply: single-file success
+// ---------------------------------------------------------------------------
+
+describe('changeModeApplier: planApply', () => {
+  test('applies a single edit to a single file', () => {
+    const root = '/project';
+    const absPath = path.resolve(root, 'src/a.ts');
+    const files: Record<string, string> = {
+      [absPath]: 'const x = 1;\nconst y = 2;\n',
+    };
+    const plan = planApply([edit('src/a.ts', 'const x = 1;', 'const x = 99;')], {
+      root,
+      readFile: makeReadFile(files),
+    });
+
+    assert.equal(plan.errors.length, 0, `unexpected errors: ${plan.errors.join('; ')}`);
+    assert.equal(plan.files.length, 1);
+    assert.ok(plan.files[0].newContent.includes('const x = 99;'));
+    assert.ok(!plan.files[0].newContent.includes('const x = 1;'));
+    assert.equal(plan.files[0].editCount, 1);
+  });
+
+  test('applies multiple edits across multiple files', () => {
+    const root = '/project';
+    const absA = path.resolve(root, 'src/a.ts');
+    const absB = path.resolve(root, 'src/b.ts');
+    const files: Record<string, string> = {
+      [absA]: 'alpha\nbeta\n',
+      [absB]: 'gamma\ndelta\n',
+    };
+    const plan = planApply(
+      [
+        edit('src/a.ts', 'alpha', 'ALPHA'),
+        edit('src/b.ts', 'gamma', 'GAMMA'),
+      ],
+      { root, readFile: makeReadFile(files) }
+    );
+
+    assert.equal(plan.errors.length, 0, `unexpected errors: ${plan.errors.join('; ')}`);
+    assert.equal(plan.files.length, 2);
+    const a = plan.files.find(f => f.path === absA)!;
+    const b = plan.files.find(f => f.path === absB)!;
+    assert.ok(a.newContent.includes('ALPHA'));
+    assert.ok(b.newContent.includes('GAMMA'));
+  });
+
+  // -----------------------------------------------------------------------
+  // Error cases
+  // -----------------------------------------------------------------------
+
+  test('OLD block not found → error recorded', () => {
+    const root = '/project';
+    const absPath = path.resolve(root, 'src/a.ts');
+    const files: Record<string, string> = {
+      [absPath]: 'const x = 1;\n',
+    };
+    const plan = planApply([edit('src/a.ts', 'DOES_NOT_EXIST', 'nope')], {
+      root,
+      readFile: makeReadFile(files),
+    });
+
+    assert.ok(plan.errors.length >= 1, 'expected at least one error');
+    assert.ok(
+      plan.errors.some(e => /not found/i.test(e)),
+      `expected "not found" error, got: ${plan.errors.join('; ')}`
+    );
+    assert.equal(plan.files.length, 0);
+  });
+
+  test('OLD block ambiguous (>1 occurrence) → error recorded', () => {
+    const root = '/project';
+    const absPath = path.resolve(root, 'src/a.ts');
+    const files: Record<string, string> = {
+      [absPath]: 'foo\nfoo\n',
+    };
+    const plan = planApply([edit('src/a.ts', 'foo', 'bar')], {
+      root,
+      readFile: makeReadFile(files),
+    });
+
+    assert.ok(plan.errors.length >= 1, 'expected at least one error');
+    assert.ok(
+      plan.errors.some(e => /ambiguous/i.test(e)),
+      `expected "ambiguous" error, got: ${plan.errors.join('; ')}`
+    );
+    assert.equal(plan.files.length, 0);
+  });
+
+  // -----------------------------------------------------------------------
+  // Path confinement
+  // -----------------------------------------------------------------------
+
+  test('rejects absolute paths', () => {
+    const root = '/project';
+    const plan = planApply([edit('/etc/passwd', 'root', 'evil')], {
+      root,
+      readFile: (_p: string) => '',
+    });
+    assert.ok(plan.errors.length >= 1, 'expected a confinement error');
+    assert.ok(
+      plan.errors.some(e => /absolute/i.test(e) || /Refusing/i.test(e)),
+      `got: ${plan.errors.join('; ')}`
+    );
+  });
+
+  test('rejects tilde-prefixed paths', () => {
+    const root = '/project';
+    const plan = planApply([edit('~/.ssh/id_rsa', 'secret', 'evil')], {
+      root,
+      readFile: (_p: string) => '',
+    });
+    assert.ok(plan.errors.length >= 1);
+    assert.ok(
+      plan.errors.some(e => /home-directory|Refusing/i.test(e)),
+      `got: ${plan.errors.join('; ')}`
+    );
+  });
+
+  test('rejects paths that escape root via ..', () => {
+    const root = '/project/src';
+    const plan = planApply([edit('../../../etc/passwd', 'root', 'evil')], {
+      root,
+      readFile: (_p: string) => '',
+    });
+    assert.ok(plan.errors.length >= 1);
+    assert.ok(
+      plan.errors.some(e => /escape|Refusing/i.test(e)),
+      `got: ${plan.errors.join('; ')}`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderDiff
+// ---------------------------------------------------------------------------
+
+describe('changeModeApplier: renderDiff', () => {
+  test('contains --- and +++ headers for each file', () => {
+    const root = '/project';
+    const absPath = path.resolve(root, 'src/a.ts');
+    const plan = planApply([edit('src/a.ts', 'old line', 'new line')], {
+      root,
+      readFile: (_p: string) => 'old line\n',
+    });
+
+    const diff = renderDiff(plan);
+    assert.ok(diff.includes('---'), 'expected --- in diff');
+    assert.ok(diff.includes('+++'), 'expected +++ in diff');
+    assert.ok(diff.includes('-old line'), 'expected -old line in diff');
+    assert.ok(diff.includes('+new line'), 'expected +new line in diff');
+  });
+
+  test('returns "(no changes)" for an empty plan', () => {
+    const emptyPlan: ApplyPlan = { files: [], errors: [] };
+    assert.equal(renderDiff(emptyPlan), '(no changes)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commitPlan: atomicity and rollback
+// ---------------------------------------------------------------------------
+
+describe('changeModeApplier: commitPlan atomicity', () => {
+  test('writes all files when no error occurs', () => {
+    withTempDir({ 'a.ts': 'old a\n', 'b.ts': 'old b\n' }, dir => {
+      const absA = path.join(dir, 'a.ts');
+      const absB = path.join(dir, 'b.ts');
+
+      const plan = planApply(
+        [edit('a.ts', 'old a', 'new a'), edit('b.ts', 'old b', 'new b')],
+        { root: dir, readFile: (p: string) => fs.readFileSync(p, 'utf8') }
+      );
+      assert.equal(plan.errors.length, 0, `plan errors: ${plan.errors.join('; ')}`);
+
+      commitPlan(plan, {
+        writeFile: (p: string, c: string) => fs.writeFileSync(p, c, 'utf8'),
+      });
+
+      assert.equal(fs.readFileSync(absA, 'utf8'), 'new a\n');
+      assert.equal(fs.readFileSync(absB, 'utf8'), 'new b\n');
+    });
+  });
+
+  test('rolls back already-written files when a later write fails', () => {
+    withTempDir({ 'a.ts': 'old a\n', 'b.ts': 'old b\n' }, dir => {
+      const absA = path.join(dir, 'a.ts');
+
+      const plan = planApply(
+        [edit('a.ts', 'old a', 'new a'), edit('b.ts', 'old b', 'new b')],
+        { root: dir, readFile: (p: string) => fs.readFileSync(p, 'utf8') }
+      );
+      assert.equal(plan.errors.length, 0, `plan errors: ${plan.errors.join('; ')}`);
+
+      let callCount = 0;
+      assert.throws(
+        () =>
+          commitPlan(plan, {
+            writeFile: (p: string, c: string) => {
+              callCount++;
+              if (callCount === 2) {
+                throw new Error('Simulated disk error on second write');
+              }
+              fs.writeFileSync(p, c, 'utf8');
+            },
+          }),
+        /Simulated disk error/
+      );
+
+      // First file must have been rolled back.
+      assert.equal(
+        fs.readFileSync(absA, 'utf8'),
+        'old a\n',
+        'first file should have been restored after rollback'
+      );
+    });
+  });
+
+  test('throws when called with a plan containing errors', () => {
+    const badPlan: ApplyPlan = {
+      files: [],
+      errors: ['something went wrong'],
+    };
+    assert.throws(
+      () => commitPlan(badPlan, { writeFile: () => {} }),
+      /errors/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds `apply-edits`, a tool that accepts the raw OLD/NEW text produced by `ask-gemini changeMode:true` and applies every edit **atomically** — all files are written or none are, with automatic rollback on partial failure. This makes repo-scale, multi-file refactors produced via changeMode safe to apply in one step.

## What changes

- `src/utils/changeModeApplier.ts` — a pure, IO-injectable utility:
  - `planApply` resolves each target path (confined to the project root; absolute, `~`-prefixed, and `..`-escaping paths rejected before any read/write), then requires each OLD block to match **exactly once** (0 → "not found", >1 → "ambiguous"), building the new file content in memory.
  - `renderDiff` produces a unified-diff preview with no external dependencies.
  - `commitPlan` validates everything first, then writes; if a write throws partway, already-written files are restored to their original content before re-throwing.
- `src/tools/apply-edits.tool.ts` — `apply-edits` UnifiedTool (category `utility`). Two-phase by design: `dryRun` (default `true`) returns the diff and writes nothing; applying requires `dryRun: false` **and** `confirm: true`.

## Verification

- `npx tsc --noEmit` — clean
- `node scripts/run-tests.mjs unit integration` — 81 pass / 0 fail (planApply success/not-found/ambiguous/path-escape, renderDiff, and commitPlan atomicity + rollback are all covered)

## Notes

- Opt-in: a new tool; no existing behavior changes.
- OLD-block matching is textual (exact substring), matching the existing changeMode contract — whitespace-divergent blocks report "not found" rather than applying a wrong edit.