### PR TITLE
feat: Gemini CLI → Antigravity CLI (agy) migration — analysis + pluggable backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ If you installed globally, use this configuration instead:
 
 After updating the configuration, restart your terminal session.
 
+### Backend selection (Gemini CLI → Antigravity `agy`)
+
+Google retires the Gemini CLI on **2026-06-18** for free/Pro/Ultra tiers. The CLI backend
+is pluggable so you can move at your own pace:
+
+| Variable | Purpose |
+| --- | --- |
+| `GEMINI_MCP_BACKEND` | `gemini` (default) or `agy`/`antigravity` to use the Antigravity CLI |
+| `AGY_CLI_PATH` | Full path to the `agy` binary if it isn't on the server's PATH |
+
+The `agy` backend is **experimental**: print-mode is Gemini 3.5 Flash–only, replies are
+recovered from `agy`'s transcript files, and tool execution isn't sandboxed in `-p`. The
+tool emits a notice whenever a requested `model` or `sandbox` can't be honored. See
+[docs/migration/antigravity-cli.md](docs/migration/antigravity-cli.md) for the full
+analysis and migration plan.
+
 ## Example Workflow
 
 - **Natural language**: "use gemini to explain index.html", "understand the massive project using gemini", "ask gemini to search for latest news"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ is pluggable so you can move at your own pace:
 | `GEMINI_MCP_BACKEND` | `gemini` (default) or `agy`/`antigravity` to use the Antigravity CLI |
 | `AGY_CLI_PATH` | Full path to the `agy` binary if it isn't on the server's PATH |
 
-The `agy` backend is **experimental**: print-mode is Gemini 3.5 Flash–only, replies are
+The `agy` backend is **experimental**: print-mode is Gemini 3.5 Flash-only, replies are
 recovered from `agy`'s transcript files, and tool execution isn't sandboxed in `-p`. The
 tool emits a notice whenever a requested `model` or `sandbox` can't be honored. See
 [docs/migration/antigravity-cli.md](docs/migration/antigravity-cli.md) for the full

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -22,7 +22,8 @@ export default withMermaid(
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Open Guide', link: '/getting-started' },
-      { text: 'API', link: '/api' }
+      { text: 'API', link: '/api' },
+      { text: 'Migration', link: '/migration/antigravity-cli' }
     ],
 
     sidebar: [
@@ -52,6 +53,13 @@ export default withMermaid(
           { text: 'Natural Language', link: '/usage/natural-language' },
           { text: 'Examples', link: '/usage/examples' },
           { text: 'Best Practices', link: '/usage/best-practices' }
+        ]
+      },
+      {
+        text: 'Migration',
+        collapsed: false,
+        items: [
+          { text: 'Gemini CLI → Antigravity (agy)', link: '/migration/antigravity-cli' },
         ]
       },
       {

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -2,6 +2,12 @@
 
 Choose the right Gemini model for your task.
 
+> **Heads up — backend matters.** Model selection below applies to the default **Gemini CLI**
+> backend. Google retires the Gemini CLI on **2026-06-18** for free/Pro/Ultra tiers; the
+> experimental **Antigravity CLI (`agy`)** backend runs print-mode as **Gemini 3.5 Flash only**
+> and ignores model selection. See the
+> [Antigravity migration guide](/migration/antigravity-cli) for details.
+
 ## Available Models
 
 ### Gemini-2.5-pro

--- a/docs/migration/antigravity-cli.md
+++ b/docs/migration/antigravity-cli.md
@@ -282,6 +282,17 @@ Because step 1 is driven by `agy --help`, the backend climbs the ladder on its o
 upstream fixes print-mode — no code change needed. Caller-supplied conversation ids
 (antigravity-cli#7) slot into the same probe when they land.
 
+Hardening (post-review):
+- **stdin routing** — changeMode/`@file` prompts carry whole inlined files, so they ride on
+  stdin exactly like the gemini path (#27/#77) instead of blowing the OS argv limit via `-p`.
+- **Error-tolerant ladder** — a non-zero exit from `agy -p` (another known 1.0.x failure
+  mode) descends the ladder instead of aborting the run; only ENOENT aborts immediately.
+- **Bounded runs** — `executeCommand` now has a 20-minute default timeout, so a hung CLI can
+  never wedge the serialized agy queue (or the server) permanently.
+- **Symlink guard everywhere** — `assertSafeFileReferences` itself now realpath-checks
+  in-root symlinks, closing the CVE-2026-0755 hole on the gemini path too (previously only
+  agy's self-inlining had the re-check).
+
 **Phase 4 — Date-aware cutover. ✅**
 `resolveDefaultBackend()` in `src/backends/index.ts` returns `gemini` until **2026-06-18** and
 `agy` from then on — because once gemini is retired, `agy` is the only live option, so the

--- a/docs/migration/antigravity-cli.md
+++ b/docs/migration/antigravity-cli.md
@@ -1,0 +1,269 @@
+# Migrating from Gemini CLI to Antigravity CLI (`agy`)
+
+> Status: **Preliminary / RFC** — this is the opening analysis for the migration, not the
+> final implementation. It exists to map the terrain before we commit code.
+>
+> Tracking discussion: [#90 — Google Ending Gemini CLI on June 18th, Gemini-mcp-tool
+> Migrating to Antigravity](https://github.com/jamubc/gemini-mcp-tool/discussions/90)
+>
+> Related prior work: [PR #78 (v1.2.0)](https://github.com/jamubc/gemini-mcp-tool/pull/78)
+> already lands a pluggable backend layer and an **experimental** `agy` backend. This
+> document is the deeper analysis behind that scaffolding and the plan to harden it.
+
+## Why this exists
+
+On **2026-06-18**, Google retires the Gemini CLI for the free, Google AI Pro, and Google
+AI Ultra tiers. After that date the `gemini` command stops serving requests for those
+accounts — no grace period, no warning at call time. Standard/Enterprise Code Assist
+licenses and paid Cloud API keys are unaffected, but the majority of this project's users
+run on exactly the tiers that lose access.
+
+`gemini-mcp-tool` is, at its core, a thin, hardened wrapper that shells out to the
+`gemini` binary (see `src/utils/geminiExecutor.ts` and `src/utils/commandExecutor.ts`).
+When that binary stops answering, every tool we expose — `ask-gemini`, `brainstorm`,
+changeMode edits, `@file` analysis — stops working for free/Pro/Ultra users on the same
+day. The official successor is the **Antigravity CLI**, invoked as **`agy`**. This is our
+plan to get there without breaking the people still on the old CLI before the cutoff.
+
+## TL;DR of what changes
+
+`agy` is not a drop-in rename of `gemini`. It is a Go-based, agent-first CLI that shares a
+runtime with the Antigravity desktop app. The surface we depend on differs in ways that
+matter for a *non-interactive, programmatic* caller like an MCP server:
+
+| Concern | Gemini CLI (today) | Antigravity CLI (`agy`) | Impact on us |
+| --- | --- | --- | --- |
+| Command | `gemini` | `agy` | Low — one constant |
+| One-shot prompt | `-p/--prompt` (also positional), prints to stdout | `-p/--print` exists but **writes nothing to stdout in 1.0.x** | **High** — our entire contract is "read stdout" |
+| Model select | `-m gemini-2.5-pro` etc. | `--model` exists, but `-p` is **hardcoded to Gemini 3.5 Flash**; switching model in `-p` hangs | **High** — breaks our Pro/Flash strategy + quota fallback |
+| `@file` inlining | CLI inlines `@path` file contents into the prompt | Not confirmed to exist; agent reads files via its own tools | **High** — `@file` is our headline feature |
+| Sandbox | `-s/--sandbox` | `--sandbox` exists but tool execution is effectively unsandboxed in `-p` | **High** — security posture changes |
+| Approval modes | `--approval-mode {default,auto_edit,yolo,plan}` | only `--dangerously-skip-permissions`, and it's a **no-op** in `-p` | **Medium/High** |
+| Sessions | `--session-id <id>`, `--resume` | `--conversation <id>`, `--continue` (continue is **global**, not per-workspace) | **Medium** — concurrency hazard |
+| Output format | `--output-format json` (structured) | `--output-format json` not reliably present in 1.0.x | **Medium** |
+| Auth | gemini OAuth / API key | OS credential store; log in once via `agy -i` | **Low/Medium** |
+| Transcript on disk | n/a (stdout is the source of truth) | JSONL transcripts under `~/.gemini/antigravity-cli/brain/...` (dual-writing `.db` now) | We currently depend on this; it's fragile |
+
+The headline: **our integration assumes a clean, synchronous "prompt in → answer on
+stdout" CLI. `agy` in its current form does not provide that.** Most of the work is
+recovering that contract on top of an agent-first tool that wasn't designed for it.
+
+---
+
+## Deep dive: where the two CLIs diverge
+
+### 1. The output contract is broken (`agy -p` empty stdout)
+
+Everything in `executeCommand()` (`src/utils/commandExecutor.ts`) is built around the
+child process writing the answer to stdout, which we accumulate and `resolve()` on a clean
+exit. In `agy` 1.0.x, `agy -p` authenticates, talks to the model, gets the answer back…
+and then **exits 0 without printing it**. A zero exit with empty stdout currently looks
+like "success, empty answer" to us.
+
+The community workaround (and what PR #78's experimental backend already does) is to stop
+trusting stdout and instead read `agy`'s own transcript:
+
+1. Map the current working directory to a conversation id via
+   `~/.gemini/antigravity-cli/cache/last_conversations.json`.
+2. Read the JSONL transcript at
+   `~/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript.jsonl`.
+3. Take the entries after the last `USER_INPUT` where
+   `source = MODEL, type = PLANNER_RESPONSE, status = DONE` and join their `content`.
+
+This works, but it's a reverse-engineered private contract:
+
+- **Format risk.** `agy` 1.0.5 already dual-writes a `.db` (SQLite) alongside JSONL. When
+  JSONL generation stops, the transcript reader breaks and we need a SQLite path.
+- **Discovery risk.** `last_conversations.json` is keyed by workspace path. If the schema,
+  key normalization, or directory layout changes, discovery silently fails.
+- **Concurrency risk.** Each run rewrites `last_conversations.json`, so two concurrent
+  runs read each other's ids back. PR #78 serializes all `agy` calls behind a promise
+  queue to avoid this — correct, but it removes parallelism.
+
+**Proposed solutions**
+- **S1 (short term):** Keep the transcript-recovery path, but treat it as a *fallback*:
+  prefer stdout when non-empty (a future `agy` may fix `-p`), and only fall back to the
+  transcript when stdout is empty. (PR #78 already does this — keep it.)
+- **S2:** Harden the reader: detect JSONL vs SQLite by what exists on disk and add a
+  SQLite reader behind the same interface so a future `agy` update doesn't break us.
+- **S3:** Capture the process start time and only accept transcript entries newer than it,
+  so we never return a stale answer from a previous run if discovery races.
+- **S4 (upstream):** Track [antigravity-cli#7](https://github.com/google-antigravity/antigravity-cli/issues/7)
+  (emit/accept a conversation id for headless callers). A caller-supplied
+  `--conversation <uuid>` would let us *know the id up front* and read the right transcript
+  deterministically instead of guessing via `last_conversations.json`. This is the clean
+  fix; everything above is scaffolding until it lands.
+
+### 2. Model selection is gone in print mode
+
+Our current value proposition leans on model choice: `ask-gemini` takes a `model` arg,
+defaults to Pro, and `executeGeminiCLI()` implements a **quota fallback from Pro → Flash**
+on `RESOURCE_EXHAUSTED` (`src/utils/geminiExecutor.ts`, `src/utils/commandExecutor.ts`).
+
+In `agy`, print mode is hardcoded to Gemini 3.5 Flash (High). `--model` exists for the
+interactive TUI but is ignored — worse, passing a non-active model label in `-p` causes
+the call to **hang** past 60s (verified on `agy` 1.0.5). So:
+
+- The `model` arg becomes a no-op (or a hazard) on the `agy` backend.
+- The Pro→Flash quota fallback is meaningless when Flash is the only option.
+- Cost/latency change: reports indicate Flash 3.5 consumes notably more tokens per task
+  than the old Flash, so "Flash is the cheap fast one" no longer holds the same way.
+
+**Proposed solutions**
+- **S5:** Make model support a backend capability, not a global assumption. PR #78 already
+  adds `supportsModelSelection` to the `Backend` interface (`src/backends/types.ts`) and
+  sets it `false` for `agy`. Build on that: when `supportsModelSelection === false`, the
+  tool layer should **not** forward `model`, should surface a one-time notice that the
+  backend is Flash-only, and should **skip the Pro→Flash fallback entirely** rather than
+  letting it look like a silent downgrade.
+- **S6:** Never pass `--model` to `agy -p` until upstream fixes the hang. Gate it behind a
+  capability + a version check so we can light it up later without a code change.
+- **S7:** Document the cost/latency delta in `docs/concepts/models.md` so users aren't
+  surprised by token consumption after the switch.
+
+### 3. `@file` — our headline feature — may not survive as-is
+
+The single most-used feature of this tool is `@file` analysis: a user writes
+`@src/huge.ts explain this` and the Gemini CLI **inlines the file contents** into the
+prompt, leveraging Gemini's large context window. We deliberately keep that behavior and
+*guard* it — `assertSafeFileReferences()` rejects `@` references that escape the project
+root (CVE-2026-0755). changeMode also rewrites `file:` → `@` to lean on the same mechanism.
+
+`agy` is agent-first: rather than the CLI textually inlining `@path`, the **agent decides**
+to read files using its own tools during a multi-step run. That's a different contract:
+
+- The inlining we rely on (and sanitize) may not happen at all, or may happen via a
+  different syntax. Our `@`-token rewriting and our security guard both assume the gemini
+  inlining model.
+- If the agent reads files itself, our path-traversal guard no longer sits in the data
+  path — the agent could read outside the project root unless `agy`'s own sandboxing
+  prevents it (and see §4: in `-p` it largely doesn't).
+- Determinism drops: "inline exactly these files" becomes "the agent will probably read
+  these files," which is worse for a programmatic tool that wants reproducible output.
+
+**Proposed solutions**
+- **S8:** Treat `@file` handling as backend-specific. For `agy`, **resolve and read the
+  referenced files ourselves** (inside the project root, reusing
+  `assertSafeFileReferences()`), then construct a prompt that embeds the contents
+  explicitly — so we keep both the determinism and the security guard regardless of what
+  the agent would do on its own.
+- **S9:** Keep `assertSafeFileReferences()` as a hard gate on the *input* prompt on every
+  backend, even if the downstream CLI changes how it consumes references. The guard is
+  cheap and the exfiltration primitive it blocks is backend-independent.
+- **S10:** Add a focused test that an `@file` prompt on the `agy` backend produces output
+  that actually reflects the file contents — this is the regression we most need to catch.
+
+### 4. Security posture: sandbox and approval flags are weaker than they look
+
+Today we forward `-s/--sandbox` and (in PR #78) `--approval-mode {default,auto_edit,yolo,
+plan}`. On `agy`:
+
+- `--sandbox` exists, but in `-p` the agent **auto-runs filesystem and network operations
+  with the user's privileges** regardless. Tool execution is effectively unsandboxed.
+- There are no graded approval modes — only `--dangerously-skip-permissions`, which is a
+  **no-op in `-p`** because there's no interactive approval gate to skip in the first
+  place. The agent already executes tools autonomously.
+
+So a user who passes `sandbox: true` expecting isolation, or who avoids `yolo` expecting a
+confirmation gate, gets neither on the `agy` backend. That's a meaningful and surprising
+change in safety semantics for anyone scripting this tool.
+
+**Proposed solutions**
+- **S11:** Map approval modes per backend (PR #78 already maps only `yolo` →
+  `--dangerously-skip-permissions`). Go further: when the requested guarantee can't be
+  honored, **say so** — e.g. if `sandbox: true` is requested on `agy`, emit a clear notice
+  that print-mode `agy` does not sandbox tool execution, rather than silently pretending.
+- **S12:** Consider making `agy`-backed tools **read-only by default** from our side: for
+  the analysis use cases this tool is built for (explain/summarize large files), we don't
+  need the agent to run tools at all. If `agy` later exposes a "no tools / planner-only"
+  print mode, prefer it. Until then, document the exposure loudly.
+- **S13:** Keep the `@file` project-root guard (S9) as the one sandbox property we *can*
+  still enforce ourselves on the input side.
+
+### 5. Sessions and concurrency
+
+We forward `--session-id`/`--resume` (gemini) which PR #78 maps to
+`--conversation`/`--continue` (agy). Two gaps:
+
+- `agy --continue` resumes the **most recent conversation globally**, not per-workspace.
+  Concurrent callers in different repos can resume each other's threads.
+- There's no way to **capture** an auto-assigned conversation id from a `-p` run
+  ([antigravity-cli#7](https://github.com/google-antigravity/antigravity-cli/issues/7)),
+  which is also why we fall back to scraping `last_conversations.json`.
+
+**Proposed solutions**
+- **S14:** Prefer explicit `--conversation <id>` over `--continue` whenever we have an id;
+  avoid relying on global "most recent" semantics.
+- **S15:** If upstream adds caller-supplied ids (S4), generate a UUID per logical session
+  on our side and pass it in, making both the resume and the transcript-read deterministic.
+- **S16:** Until then, keep PR #78's serialized `agy` queue, and document that `agy`-backed
+  sessions are best-effort and not safe to run concurrently across workspaces.
+
+### 6. Packaging, auth, and detection
+
+- `agy` is a Go binary installed to `~/.local/bin/` (Unix) or `%LOCALAPPDATA%\Antigravity\`
+  (Windows) — not an npm global like `@google/gemini-cli`. Our Windows PATH-resolution
+  logic in `commandExecutor.ts` (`resolveCommandForExecution`, the `where`-based shim
+  lookup) is gemini-specific and won't find `agy` the same way.
+- Auth is via the OS credential store after a one-time `agy -i` login, versus gemini's
+  OAuth/API-key flow.
+- Our error messaging (`buildEnoentErrorMessage`) hard-codes
+  `npm install -g @google/gemini-cli` guidance.
+
+**Proposed solutions**
+- **S17:** Generalize executable resolution to also locate `agy` (its known install dirs +
+  an `AGY_CLI_PATH`-style override, mirroring `GEMINI_CLI_PATH`).
+- **S18:** Make `buildEnoentErrorMessage` backend-aware so an `agy` user gets `agy`-correct
+  install/login guidance (including `agy -i`), not a gemini npm command.
+- **S19:** Extend the existing **setup doctor** (`scripts/doctor.mjs`, added in PR #78) to
+  detect both CLIs, report versions, and warn when the active backend's binary is missing
+  or unauthenticated. The doctor is the right place to make all of this legible to users.
+
+---
+
+## Proposed migration phases
+
+**Phase 0 — Backend seam (done in PR #78).** Pluggable backends, `GEMINI_MCP_BACKEND`,
+capability flags, and an experimental `agy` backend with transcript recovery. This RFC is
+the analysis behind it.
+
+**Phase 1 — Make `agy` honest (this migration's first code).**
+- Capability-gate model selection and quota fallback (S5/S6).
+- Backend-aware `@file` handling with the project-root guard preserved (S8/S9).
+- Truthful sandbox/approval notices on `agy` (S11/S12).
+- Backend-aware detection, errors, and doctor coverage (S17–S19).
+
+**Phase 2 — Harden the recovery path.**
+- JSONL **and** SQLite transcript readers behind one interface (S2).
+- Start-time-bounded reads (S3) and explicit-id sessions where possible (S14/S15).
+
+**Phase 3 — Track upstream and graduate.**
+- Adopt caller-supplied conversation ids and any `-p` stdout / `--output-format json` fix
+  (S4) the moment they land, then drop the transcript-scraping fallback.
+- Promote `agy` from experimental to a first-class (eventually default) backend once `-p`
+  prints reliably and model selection works in print mode.
+
+**Phase 4 — Flip the default.** Before 2026-06-18, default new installs to `agy` while
+keeping `gemini` selectable for Standard/Enterprise/API-key users who retain access.
+
+## Open questions
+
+1. Does any `agy` version inline `@file`-style references, or must we always read files
+   ourselves (S8)? This decides how much of changeMode's `file:`→`@` rewrite we keep.
+2. Is there a planner-only / no-tools print mode we can target for safe read-only analysis
+   (S12)? That would resolve most of §4 cleanly.
+3. What is the real, supported headless output contract once `-p` stdout and
+   `--output-format json` are fixed? Phase 3 hinges on it.
+4. Will `agy` be open source (gemini-cli is Apache-2.0)? That affects how aggressively we
+   can rely on internal file formats vs. wait for a public contract.
+
+## Sources
+
+- [Google Developers Blog — Transitioning Gemini CLI to Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)
+- [google-gemini/gemini-cli Discussion #27274 — official transition announcement](https://github.com/google-gemini/gemini-cli/discussions/27274)
+- [google-antigravity/antigravity-cli Issue #7 — conversation ids for headless callers](https://github.com/google-antigravity/antigravity-cli/issues/7)
+- [Community MCP bridge documenting the `agy -p` empty-stdout bug and transcript recovery](https://github.com/SinanTufekci/Claude-Code-Antigravity-CLI-MCP-Server)
+- [Antigravity CLI usage docs](https://antigravity.google/docs/cli-using)
+- This repo: [PR #78 (v1.2.0)](https://github.com/jamubc/gemini-mcp-tool/pull/78) ·
+  [Discussion #90](https://github.com/jamubc/gemini-mcp-tool/discussions/90)
+</content>

--- a/docs/migration/antigravity-cli.md
+++ b/docs/migration/antigravity-cli.md
@@ -264,27 +264,44 @@ Pluggable backends under `src/backends/` (`Backend` interface + `getBackend()` +
 - Discovery is start-time-bounded (`newestConversationSince`) so we never return a stale
   reply, and explicit `--conversation` ids are read back deterministically (S3/S14).
 
-**Phase 3 — Track upstream and graduate. 🔜/⏳**
-- We already prefer stdout when non-empty, so the day `agy -p` prints reliably the
-  transcript fallback simply stops being used (S4).
-- Adopt caller-supplied conversation ids and `--output-format json` once they land
-  upstream, then delete the scraping path and flip `supportsModelSelection` on.
+**Phase 3 — Converge on stdout; self-retire the scrape. ✅**
+Output recovery is now a capability-aware ladder (`agyCapabilities.ts`, `agyOutput.ts`),
+ordered best → last-resort, in `agyBackend.run`:
+1. **Clean JSON stdout** — `probeAgyCapabilities()` reads `agy --help` once per process; if
+   the build advertises `--output-format json`, we pass it and parse the reply off stdout
+   (`parseAgyJsonResponse`). No transcript touched (S4).
+2. **Plain stdout** — used whenever non-empty, so the day `agy -p` prints reliably the
+   fallback simply stops running.
+3. **PTY recovery (opt-in, `AGY_MCP_PTY=1`, POSIX)** — runs `agy` under a pseudo-terminal via
+   `script(1)` so a TTY-only build still streams real stdout, with **no** private files read
+   (S1b). Best-effort: absent `script`/output, it falls through. Args are POSIX-quoted, so the
+   non-PTY path's injection safety is preserved.
+4. **Transcript scrape** — the Phase 2 last resort.
 
-**Phase 4 — Flip the default. 🔜**
-`DEFAULT_BACKEND` in `src/backends/index.ts` is a one-line switch. Before 2026-06-18,
-default new installs to `agy` while keeping `gemini` selectable for Standard/Enterprise/
-API-key users who retain access.
+Because step 1 is driven by `agy --help`, the backend climbs the ladder on its own as
+upstream fixes print-mode — no code change needed. Caller-supplied conversation ids
+(antigravity-cli#7) slot into the same probe when they land.
+
+**Phase 4 — Date-aware cutover. ✅**
+`resolveDefaultBackend()` in `src/backends/index.ts` returns `gemini` until **2026-06-18** and
+`agy` from then on — because once gemini is retired, `agy` is the only live option, so the
+default flips automatically (no release required on the day). `GEMINI_MCP_BACKEND` always
+overrides. `backendSelection()` surfaces a notice on the post-retirement auto-switch and a
+one-time nudge to test `agy` in the final `RETIREMENT.WARN_WITHIN_DAYS` countdown. Standard/
+Enterprise/API-key users who retain `gemini` access just set `GEMINI_MCP_BACKEND=gemini`.
 
 ## Configuration (added in this PR)
 
 | Variable | Purpose |
 | --- | --- |
-| `GEMINI_MCP_BACKEND` | `gemini` (default) or `agy`/`antigravity` to select the CLI backend |
+| `GEMINI_MCP_BACKEND` | `gemini` or `agy`/`antigravity`; unset uses the date-aware default (Phase 4) |
 | `AGY_CLI_PATH` | Full path to the `agy` binary when it isn't on the server's PATH |
+| `AGY_MCP_PTY` | `1` to enable opt-in PTY stdout recovery for `agy -p` (POSIX only, Phase 3) |
 
-`agy` is **experimental**: print-mode is Gemini 3.5 Flash-only, output is recovered from
-`agy`'s transcript files, and tool execution is not sandboxed in `-p`. The tool surfaces a
-notice whenever a requested `model` or `sandbox` can't be honored.
+`agy` is **experimental**: print-mode is Gemini 3.5 Flash-only, output is recovered via the
+Phase 3 ladder (clean JSON stdout → plain stdout → opt-in PTY → transcript), and tool
+execution is not sandboxed in `-p`. The tool surfaces a notice whenever a requested `model`
+or `sandbox` can't be honored.
 
 ## Open questions
 

--- a/docs/migration/antigravity-cli.md
+++ b/docs/migration/antigravity-cli.md
@@ -34,7 +34,7 @@ matter for a *non-interactive, programmatic* caller like an MCP server:
 | Concern | Gemini CLI (today) | Antigravity CLI (`agy`) | Impact on us |
 | --- | --- | --- | --- |
 | Command | `gemini` | `agy` | Low — one constant |
-| One-shot prompt | `-p/--prompt` (also positional), prints to stdout | `-p/--print` exists but **writes nothing to stdout in 1.0.x** | **High** — our entire contract is "read stdout" |
+| One-shot prompt | `-p/--prompt` (also positional), prints to stdout | `-p/--print` exists but **frequently writes nothing to stdout in 1.0.x** (reported in non-TTY/headless and Windows contexts) | **High** — our entire contract is "read stdout" |
 | Model select | `-m gemini-2.5-pro` etc. | `--model` exists, but `-p` is **hardcoded to Gemini 3.5 Flash**; switching model in `-p` hangs | **High** — breaks our Pro/Flash strategy + quota fallback |
 | `@file` inlining | CLI inlines `@path` file contents into the prompt | Not confirmed to exist; agent reads files via its own tools | **High** — `@file` is our headline feature |
 | Sandbox | `-s/--sandbox` | `--sandbox` exists but tool execution is effectively unsandboxed in `-p` | **High** — security posture changes |
@@ -56,12 +56,13 @@ recovering that contract on top of an agent-first tool that wasn't designed for 
 
 Everything in `executeCommand()` (`src/utils/commandExecutor.ts`) is built around the
 child process writing the answer to stdout, which we accumulate and `resolve()` on a clean
-exit. In `agy` 1.0.x, `agy -p` authenticates, talks to the model, gets the answer back…
+exit. In `agy` 1.0.x — at least in the non-TTY/headless contexts an MCP server runs in, and
+reported on Windows — `agy -p` authenticates, talks to the model, gets the answer back…
 and then **exits 0 without printing it**. A zero exit with empty stdout currently looks
 like "success, empty answer" to us.
 
-The community workaround (and what PR #78's experimental backend already does) is to stop
-trusting stdout and instead read `agy`'s own transcript:
+Our workaround is to stop trusting stdout and read `agy`'s own transcript directly from its
+observable on-disk format (the path PR #78's experimental backend also takes):
 
 1. Map the current working directory to a conversation id via
    `~/.gemini/antigravity-cli/cache/last_conversations.json`.
@@ -70,10 +71,15 @@ trusting stdout and instead read `agy`'s own transcript:
 3. Take the entries after the last `USER_INPUT` where
    `source = MODEL, type = PLANNER_RESPONSE, status = DONE` and join their `content`.
 
+(Our implementation prefers a conversation id we set explicitly via `--conversation`, then
+the cwd→id map above, then the newest recently-written conversation — see Phase 2.)
+
 This works, but it's a reverse-engineered private contract:
 
-- **Format risk.** `agy` 1.0.5 already dual-writes a `.db` (SQLite) alongside JSONL. When
-  JSONL generation stops, the transcript reader breaks and we need a SQLite path.
+- **Format risk.** `agy` 1.0.5 already dual-writes a `.db` (SQLite) — reported both
+  alongside the JSONL and under a separate `~/.gemini/antigravity-cli/conversations/<id>.db`,
+  so the reader must probe both. When JSONL generation stops, the transcript reader breaks
+  and we need the SQLite path.
 - **Discovery risk.** `last_conversations.json` is keyed by workspace path. If the schema,
   key normalization, or directory layout changes, discovery silently fails.
 - **Concurrency risk.** Each run rewrites `last_conversations.json`, so two concurrent
@@ -83,7 +89,14 @@ This works, but it's a reverse-engineered private contract:
 **Proposed solutions**
 - **S1 (short term):** Keep the transcript-recovery path, but treat it as a *fallback*:
   prefer stdout when non-empty (a future `agy` may fix `-p`), and only fall back to the
-  transcript when stdout is empty. (PR #78 already does this — keep it.)
+  transcript when stdout is empty.
+- **S1b (the fix we'd rather own — no private formats):** The empty-stdout behaviour looks
+  like `agy`'s non-TTY output path. Drive `agy -p` under an allocated **pseudo-terminal** so
+  it believes it's interactive and streams to a pipe we capture — recovering the real stdout
+  contract without reading any of `agy`'s internal files at all. This is the approach to own
+  long-term; the transcript reader is the dependency-free interim while we evaluate the PTY
+  cost. *We solve this ourselves by observing `agy`'s actual behaviour — not by importing
+  anyone else's wrapper.*
 - **S2:** Harden the reader: detect JSONL vs SQLite by what exists on disk and add a
   SQLite reader behind the same interface so a future `agy` update doesn't break us.
 - **S3:** Capture the process start time and only accept transcript entries newer than it,
@@ -106,8 +119,8 @@ the call to **hang** past 60s (verified on `agy` 1.0.5). So:
 
 - The `model` arg becomes a no-op (or a hazard) on the `agy` backend.
 - The Pro→Flash quota fallback is meaningless when Flash is the only option.
-- Cost/latency change: reports indicate Flash 3.5 consumes notably more tokens per task
-  than the old Flash, so "Flash is the cheap fast one" no longer holds the same way.
+- Cost/latency change: reports indicate Gemini 3.5 Flash consumes notably more tokens per
+  task than the old Flash, so "Flash is the cheap fast one" no longer holds the same way.
 
 **Proposed solutions**
 - **S5:** Make model support a backend capability, not a global assumption. PR #78 already
@@ -155,8 +168,8 @@ to read files using its own tools during a multi-step run. That's a different co
 
 ### 4. Security posture: sandbox and approval flags are weaker than they look
 
-Today we forward `-s/--sandbox` and (in PR #78) `--approval-mode {default,auto_edit,yolo,
-plan}`. On `agy`:
+Today we forward `-s/--sandbox` and (in PR #78) `--approval-mode {default,auto_edit,yolo,plan}`.
+On `agy`:
 
 - `--sandbox` exists, but in `-p` the agent **auto-runs filesystem and network operations
   with the user's privileges** regardless. Tool execution is effectively unsandboxed.
@@ -215,9 +228,9 @@ We forward `--session-id`/`--resume` (gemini) which PR #78 maps to
   an `AGY_CLI_PATH`-style override, mirroring `GEMINI_CLI_PATH`).
 - **S18:** Make `buildEnoentErrorMessage` backend-aware so an `agy` user gets `agy`-correct
   install/login guidance (including `agy -i`), not a gemini npm command.
-- **S19:** Extend the existing **setup doctor** (`scripts/doctor.mjs`, added in PR #78) to
-  detect both CLIs, report versions, and warn when the active backend's binary is missing
-  or unauthenticated. The doctor is the right place to make all of this legible to users.
+- **S19:** Extend the existing **setup doctor** (`scripts/doctor.mjs`) to detect both CLIs,
+  report versions, and warn when the active backend's binary is missing or unauthenticated.
+  The doctor is the right place to make all of this legible to users.
 
 ---
 
@@ -269,7 +282,7 @@ API-key users who retain access.
 | `GEMINI_MCP_BACKEND` | `gemini` (default) or `agy`/`antigravity` to select the CLI backend |
 | `AGY_CLI_PATH` | Full path to the `agy` binary when it isn't on the server's PATH |
 
-`agy` is **experimental**: print-mode is Gemini 3.5 Flash–only, output is recovered from
+`agy` is **experimental**: print-mode is Gemini 3.5 Flash-only, output is recovered from
 `agy`'s transcript files, and tool execution is not sandboxed in `-p`. The tool surfaces a
 notice whenever a requested `model` or `sandbox` can't be honored.
 
@@ -289,8 +302,6 @@ notice whenever a requested `model` or `sandbox` can't be honored.
 - [Google Developers Blog — Transitioning Gemini CLI to Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)
 - [google-gemini/gemini-cli Discussion #27274 — official transition announcement](https://github.com/google-gemini/gemini-cli/discussions/27274)
 - [google-antigravity/antigravity-cli Issue #7 — conversation ids for headless callers](https://github.com/google-antigravity/antigravity-cli/issues/7)
-- [Community MCP bridge documenting the `agy -p` empty-stdout bug and transcript recovery](https://github.com/SinanTufekci/Claude-Code-Antigravity-CLI-MCP-Server)
 - [Antigravity CLI usage docs](https://antigravity.google/docs/cli-using)
 - This repo: [PR #78 (v1.2.0)](https://github.com/jamubc/gemini-mcp-tool/pull/78) ·
   [Discussion #90](https://github.com/jamubc/gemini-mcp-tool/discussions/90)
-</content>

--- a/docs/migration/antigravity-cli.md
+++ b/docs/migration/antigravity-cli.md
@@ -221,30 +221,57 @@ We forward `--session-id`/`--resume` (gemini) which PR #78 maps to
 
 ---
 
-## Proposed migration phases
+## Migration phases
 
-**Phase 0 — Backend seam (done in PR #78).** Pluggable backends, `GEMINI_MCP_BACKEND`,
-capability flags, and an experimental `agy` backend with transcript recovery. This RFC is
-the analysis behind it.
+Status legend: ✅ implemented in this PR · 🔜 follow-up · ⏳ blocked on upstream.
 
-**Phase 1 — Make `agy` honest (this migration's first code).**
-- Capability-gate model selection and quota fallback (S5/S6).
-- Backend-aware `@file` handling with the project-root guard preserved (S8/S9).
-- Truthful sandbox/approval notices on `agy` (S11/S12).
-- Backend-aware detection, errors, and doctor coverage (S17–S19).
+**Phase 0 — Backend seam. ✅**
+Pluggable backends under `src/backends/` (`Backend` interface + `getBackend()` +
+`runWithBackend()`), selected with `GEMINI_MCP_BACKEND`. Capability flags
+(`supportsModelSelection`, `sandboxIsolatesToolExecution`) describe each CLI honestly.
+`ask-gemini` and `brainstorm` now run through the seam; the default stays `gemini`.
+(Naming mirrors the experimental backend in #78 so the two reconcile mechanically.)
 
-**Phase 2 — Harden the recovery path.**
-- JSONL **and** SQLite transcript readers behind one interface (S2).
-- Start-time-bounded reads (S3) and explicit-id sessions where possible (S14/S15).
+**Phase 1 — Make `agy` honest. ✅**
+- Model selection is capability-gated: on `agy` the `model` arg is dropped, the Pro→Flash
+  quota fallback is skipped, and a notice explains why (S5/S6). We never pass `--model` to
+  `agy -p` (it hangs).
+- `@file` is handled per backend: `inlineFileReferences()` reads referenced files
+  ourselves for `agy`, keeping determinism **and** the CVE-2026-0755 project-root guard in
+  the data path (S8/S9).
+- Sandbox is truthful: requesting `sandbox` on `agy` returns a notice that print-mode does
+  not isolate tool execution, instead of implying isolation (S11/S12).
+- Detection is backend-aware: `AGY_CLI_PATH` override + known-install-dir/`where`
+  resolution, and `agy`-correct ENOENT guidance (install + `agy -i`), not the gemini npm
+  hint (S17/S18).
 
-**Phase 3 — Track upstream and graduate.**
-- Adopt caller-supplied conversation ids and any `-p` stdout / `--output-format json` fix
-  (S4) the moment they land, then drop the transcript-scraping fallback.
-- Promote `agy` from experimental to a first-class (eventually default) backend once `-p`
-  prints reliably and model selection works in print mode.
+**Phase 2 — Harden the recovery path. ✅**
+- `agyTranscript.ts` reads JSONL **and** detects/reads the dual-written SQLite `.db` behind
+  one `readTranscriptResponse()` interface (S2).
+- Discovery is start-time-bounded (`newestConversationSince`) so we never return a stale
+  reply, and explicit `--conversation` ids are read back deterministically (S3/S14).
 
-**Phase 4 — Flip the default.** Before 2026-06-18, default new installs to `agy` while
-keeping `gemini` selectable for Standard/Enterprise/API-key users who retain access.
+**Phase 3 — Track upstream and graduate. 🔜/⏳**
+- We already prefer stdout when non-empty, so the day `agy -p` prints reliably the
+  transcript fallback simply stops being used (S4).
+- Adopt caller-supplied conversation ids and `--output-format json` once they land
+  upstream, then delete the scraping path and flip `supportsModelSelection` on.
+
+**Phase 4 — Flip the default. 🔜**
+`DEFAULT_BACKEND` in `src/backends/index.ts` is a one-line switch. Before 2026-06-18,
+default new installs to `agy` while keeping `gemini` selectable for Standard/Enterprise/
+API-key users who retain access.
+
+## Configuration (added in this PR)
+
+| Variable | Purpose |
+| --- | --- |
+| `GEMINI_MCP_BACKEND` | `gemini` (default) or `agy`/`antigravity` to select the CLI backend |
+| `AGY_CLI_PATH` | Full path to the `agy` binary when it isn't on the server's PATH |
+
+`agy` is **experimental**: print-mode is Gemini 3.5 Flash–only, output is recovered from
+`agy`'s transcript files, and tool execution is not sandboxed in `-p`. The tool surfaces a
+notice whenever a requested `model` or `sandbox` can't be honored.
 
 ## Open questions
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -28,6 +28,13 @@ npm install -g @google/gemini-cli
 ```
 Then, run "gemini" and complete auth.
 
+### What happens after June 18, 2026?
+Google retires the Gemini CLI on **2026-06-18** for free, Pro, and Ultra tiers (Standard/
+Enterprise and paid Cloud API keys keep working). Its successor is the **Antigravity CLI
+(`agy`)**. This tool ships an experimental `agy` backend — set `GEMINI_MCP_BACKEND=agy` to
+try it — and the default will switch ahead of the cutoff. See the
+[Antigravity migration guide](/migration/antigravity-cli).
+
 ### Can I use this with Claude Code?
 Yes! It works with both Claude Desktop and Claude Code.
 

--- a/src/backends/agy.ts
+++ b/src/backends/agy.ts
@@ -2,8 +2,8 @@ import { Logger } from "../utils/logger.js";
 import { CLI, APPROVAL_MODES } from "../constants.js";
 import { executeCommand } from "../utils/commandExecutor.js";
 import {
-  buildChangeModePrompt,
   inlineFileReferences,
+  prepareChangeModePrompt,
 } from "../utils/geminiExecutor.js";
 import {
   conversationIdForCwd,
@@ -20,26 +20,28 @@ import type { Backend, BackendRunOptions } from "./types.js";
  * agy is gemini-cli's successor (Gemini CLI retires 2026-06-18 for free/Pro/Ultra
  * tiers). The migration analysis behind this lives in
  * docs/migration/antigravity-cli.md. The behaviours that shape this code:
- *  1. `agy -p` is broken in 1.0.x — exit 0, empty stdout. Phase 3 makes output
- *     recovery a self-retiring ladder (best → last-resort): clean JSON stdout
- *     when the build advertises `--output-format json`; else plain stdout; else
- *     an opt-in pseudo-terminal run (AGY_MCP_PTY=1) that coaxes a TTY-only build
- *     into printing; else the on-disk transcript (agyTranscript.ts). As agy
- *     improves, capability probing shifts us up the ladder with no code change.
+ *  1. `agy -p` is broken in 1.0.x — exit 0, empty stdout (and sometimes a
+ *     non-zero exit). Phase 3 makes output recovery a self-retiring ladder
+ *     (best → last-resort): clean JSON stdout when the build advertises
+ *     `--output-format json`; else plain stdout; else an opt-in pseudo-terminal
+ *     run (AGY_MCP_PTY=1) that coaxes a TTY-only build into printing; else the
+ *     on-disk transcript (agyTranscript.ts). A failed print run descends the
+ *     ladder rather than aborting. As agy improves, capability probing shifts
+ *     us up the ladder with no code change.
  *  2. Print-mode is hardcoded to Gemini 3.5 Flash; `--model` is ignored and
  *     hangs if forced. supportsModelSelection is false; we never pass --model.
  *  3. `@file` is not inlined by agy (it's agent-first). We inline files ourselves
- *     so the project-root guard and determinism survive.
+ *     so the project-root guard and determinism survive — and because inlined
+ *     prompts carry whole files, they ride on stdin to dodge OS argv limits.
  *  4. `--sandbox`/`--dangerously-skip-permissions` do NOT isolate tool execution
  *     in -p. We surface that truthfully instead of implying isolation.
  */
 
 /** Build the prompt agy actually receives: changeMode wrap + self-inlined files. */
 export function buildAgyPrompt(prompt: string, opts: BackendRunOptions): string {
-  let processed = prompt;
-  if (opts.changeMode) {
-    processed = buildChangeModePrompt(processed.replace(/file:(\S+)/g, "@$1"));
-  }
+  // Shared changeMode preprocessing with the gemini backend, so the two
+  // backends produce the same prompt body for the same request.
+  const processed = opts.changeMode ? prepareChangeModePrompt(prompt) : prompt;
   // agy doesn't inline @file; do it ourselves (keeps the CVE-2026-0755 guard).
   return inlineFileReferences(processed);
 }
@@ -70,6 +72,11 @@ function explicitConversationId(opts: BackendRunOptions): string | undefined {
   return undefined;
 }
 
+/** One raw output channel → the reply, honouring JSON mode; undefined if empty. */
+function replyFrom(raw: string, jsonMode: boolean): string | undefined {
+  return jsonMode ? parseAgyJsonResponse(raw) : raw.trim() || undefined;
+}
+
 // Serialize agy calls: each run rewrites last_conversations.json, so concurrent
 // runs would read each other's conversation ids back.
 let agyQueue: Promise<unknown> = Promise.resolve();
@@ -92,21 +99,40 @@ export const agyBackend: Backend = {
       // When the build supports it, ask for JSON so we read a clean answer off
       // stdout instead of scraping the transcript.
       if (caps.outputFormatJson) baseArgs.push("--output-format", "json");
-      const args = [...baseArgs, "-p", finalPrompt];
+
+      // changeMode/@file prompts carry whole inlined files, easily exceeding
+      // the OS argv limits — route them via stdin, exactly as the gemini path
+      // does (#27, #77). Decide on the ORIGINAL prompt: inlining has already
+      // replaced the @ tokens in finalPrompt.
+      const useStdin = !!opts.changeMode || prompt.includes("@");
+      const argsWithPrompt = [...baseArgs, "-p", finalPrompt];
 
       // 1) Direct stdout — the clean path (JSON when available, else plain text).
-      const stdout = await executeCommand(CLI.COMMANDS.AGY, args, opts.onProgress);
-      const direct = caps.outputFormatJson
-        ? parseAgyJsonResponse(stdout)
-        : stdout.trim() || undefined;
+      // A non-zero exit is one of 1.0.x's known print-mode failure modes; the
+      // answer may still have landed in the transcript, so a failure here
+      // descends the ladder instead of aborting the run.
+      let stdout = "";
+      let printError: Error | undefined;
+      try {
+        stdout = useStdin
+          ? await executeCommand(CLI.COMMANDS.AGY, baseArgs, opts.onProgress, finalPrompt)
+          : await executeCommand(CLI.COMMANDS.AGY, argsWithPrompt, opts.onProgress);
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        // Not installed: nothing further down the ladder can succeed.
+        if (err.message.includes("Could not find")) throw err;
+        Logger.warn(`agy: print-mode failed (${err.message}); trying recovery.`);
+        printError = err;
+      }
+      const direct = replyFrom(stdout, caps.outputFormatJson);
       if (direct) return direct;
 
       // 2) Opt-in PTY recovery: a TTY-only build prints under a pseudo-terminal.
+      // script(1) cannot feed stdin, so the prompt rides in argv here; an
+      // over-long argv just fails the spawn and falls through to rung 3.
       if (ptyEnabled()) {
-        const ptyOut = await runAgyUnderPty(args, opts.onProgress);
-        const fromPty = caps.outputFormatJson
-          ? parseAgyJsonResponse(ptyOut)
-          : ptyOut.trim() || undefined;
+        const ptyOut = await runAgyUnderPty(argsWithPrompt, opts.onProgress);
+        const fromPty = replyFrom(ptyOut, caps.outputFormatJson);
         if (fromPty) return fromPty;
       }
 
@@ -116,6 +142,8 @@ export const agyBackend: Backend = {
         conversationIdForCwd(cwd) ??
         newestConversationSince(startMs);
       if (!id) {
+        // Nothing recoverable: surface the print failure if there was one.
+        if (printError) throw printError;
         throw new Error(
           `agy: produced no stdout and no conversation id was found for ${cwd}. ` +
             "Run `agy -i` once to authenticate, then retry.",

--- a/src/backends/agy.ts
+++ b/src/backends/agy.ts
@@ -1,0 +1,110 @@
+import { Logger } from "../utils/logger.js";
+import { CLI, APPROVAL_MODES } from "../constants.js";
+import { executeCommand } from "../utils/commandExecutor.js";
+import {
+  buildChangeModePrompt,
+  inlineFileReferences,
+} from "../utils/geminiExecutor.js";
+import {
+  conversationIdForCwd,
+  newestConversationSince,
+  readTranscriptResponse,
+} from "./agyTranscript.js";
+import type { Backend, BackendRunOptions } from "./types.js";
+
+/**
+ * EXPERIMENTAL Antigravity CLI (`agy`) backend — opt in with GEMINI_MCP_BACKEND=agy.
+ *
+ * agy is gemini-cli's successor (Gemini CLI retires 2026-06-18 for free/Pro/Ultra
+ * tiers). The migration analysis behind this lives in
+ * docs/migration/antigravity-cli.md. The behaviours that shape this code:
+ *  1. `agy -p` is broken in 1.0.x — exit 0, empty stdout. We recover the reply
+ *     from agy's transcript on disk (agyTranscript.ts), preferring stdout when a
+ *     future agy fixes it (Phase 3).
+ *  2. Print-mode is hardcoded to Gemini 3.5 Flash; `--model` is ignored and
+ *     hangs if forced. supportsModelSelection is false; we never pass --model.
+ *  3. `@file` is not inlined by agy (it's agent-first). We inline files ourselves
+ *     so the project-root guard and determinism survive.
+ *  4. `--sandbox`/`--dangerously-skip-permissions` do NOT isolate tool execution
+ *     in -p. We surface that truthfully instead of implying isolation.
+ */
+
+/** Build the prompt agy actually receives: changeMode wrap + self-inlined files. */
+export function buildAgyPrompt(prompt: string, opts: BackendRunOptions): string {
+  let processed = prompt;
+  if (opts.changeMode) {
+    processed = buildChangeModePrompt(processed.replace(/file:(\S+)/g, "@$1"));
+  }
+  // agy doesn't inline @file; do it ourselves (keeps the CVE-2026-0755 guard).
+  return inlineFileReferences(processed);
+}
+
+export function buildAgyArgs(opts: BackendRunOptions): string[] {
+  const args: string[] = [];
+  // Sessions: --continue resumes the most recent (global!); --conversation <id>
+  // a specific one. Prefer an explicit id whenever we have one.
+  if (opts.resume) {
+    if (opts.resume === "latest") args.push("--continue");
+    else args.push("--conversation", opts.resume);
+  } else if (opts.sessionId) {
+    args.push("--conversation", opts.sessionId);
+  }
+  if (opts.sandbox) args.push("--sandbox"); // forwarded, but see sandbox notice
+  // agy has no graded approval modes; only "skip all prompts" maps cleanly.
+  if (opts.approvalMode === APPROVAL_MODES.YOLO) {
+    args.push("--dangerously-skip-permissions");
+  }
+  // Print mode is hardcoded to Flash — deliberately NO --model (it hangs -p).
+  return args;
+}
+
+/** The conversation id to read back, if we already know it from the args. */
+function explicitConversationId(opts: BackendRunOptions): string | undefined {
+  if (opts.resume && opts.resume !== "latest") return opts.resume;
+  if (!opts.resume && opts.sessionId) return opts.sessionId;
+  return undefined;
+}
+
+// Serialize agy calls: each run rewrites last_conversations.json, so concurrent
+// runs would read each other's conversation ids back.
+let agyQueue: Promise<unknown> = Promise.resolve();
+
+export const agyBackend: Backend = {
+  name: "agy",
+  supportsModelSelection: false, // print-mode is hardcoded to Gemini 3.5 Flash
+  sandboxIsolatesToolExecution: false, // -p runs tools with user privileges
+  run(prompt: string, opts: BackendRunOptions): Promise<string> {
+    const task = agyQueue.then(async () => {
+      Logger.warn(
+        "[experimental] agy backend: print-mode is Flash-only and recovers output from transcript files.",
+      );
+
+      const cwd = process.cwd();
+      const startMs = Date.now();
+      const finalPrompt = buildAgyPrompt(prompt, opts);
+      const args = [...buildAgyArgs(opts), "-p", finalPrompt];
+
+      const stdout = await executeCommand(CLI.COMMANDS.AGY, args, opts.onProgress);
+      if (stdout && stdout.trim()) return stdout.trim(); // Phase 3: future agy may fix -p
+
+      // Recover from the transcript: prefer an id we set, else discover it.
+      const id =
+        explicitConversationId(opts) ??
+        conversationIdForCwd(cwd) ??
+        newestConversationSince(startMs);
+      if (!id) {
+        throw new Error(
+          `agy: produced no stdout and no conversation id was found for ${cwd}. ` +
+            "Run `agy -i` once to authenticate, then retry.",
+        );
+      }
+      return readTranscriptResponse(id);
+    });
+    // Keep the chain alive regardless of this call's outcome.
+    agyQueue = task.then(
+      () => undefined,
+      () => undefined,
+    );
+    return task;
+  },
+};

--- a/src/backends/agy.ts
+++ b/src/backends/agy.ts
@@ -10,6 +10,8 @@ import {
   newestConversationSince,
   readTranscriptResponse,
 } from "./agyTranscript.js";
+import { probeAgyCapabilities } from "./agyCapabilities.js";
+import { parseAgyJsonResponse, ptyEnabled, runAgyUnderPty } from "./agyOutput.js";
 import type { Backend, BackendRunOptions } from "./types.js";
 
 /**
@@ -18,9 +20,12 @@ import type { Backend, BackendRunOptions } from "./types.js";
  * agy is gemini-cli's successor (Gemini CLI retires 2026-06-18 for free/Pro/Ultra
  * tiers). The migration analysis behind this lives in
  * docs/migration/antigravity-cli.md. The behaviours that shape this code:
- *  1. `agy -p` is broken in 1.0.x — exit 0, empty stdout. We recover the reply
- *     from agy's transcript on disk (agyTranscript.ts), preferring stdout when a
- *     future agy fixes it (Phase 3).
+ *  1. `agy -p` is broken in 1.0.x — exit 0, empty stdout. Phase 3 makes output
+ *     recovery a self-retiring ladder (best → last-resort): clean JSON stdout
+ *     when the build advertises `--output-format json`; else plain stdout; else
+ *     an opt-in pseudo-terminal run (AGY_MCP_PTY=1) that coaxes a TTY-only build
+ *     into printing; else the on-disk transcript (agyTranscript.ts). As agy
+ *     improves, capability probing shifts us up the ladder with no code change.
  *  2. Print-mode is hardcoded to Gemini 3.5 Flash; `--model` is ignored and
  *     hangs if forced. supportsModelSelection is false; we never pass --model.
  *  3. `@file` is not inlined by agy (it's agent-first). We inline files ourselves
@@ -81,13 +86,31 @@ export const agyBackend: Backend = {
 
       const cwd = process.cwd();
       const startMs = Date.now();
+      const caps = await probeAgyCapabilities();
       const finalPrompt = buildAgyPrompt(prompt, opts);
-      const args = [...buildAgyArgs(opts), "-p", finalPrompt];
+      const baseArgs = buildAgyArgs(opts);
+      // When the build supports it, ask for JSON so we read a clean answer off
+      // stdout instead of scraping the transcript.
+      if (caps.outputFormatJson) baseArgs.push("--output-format", "json");
+      const args = [...baseArgs, "-p", finalPrompt];
 
+      // 1) Direct stdout — the clean path (JSON when available, else plain text).
       const stdout = await executeCommand(CLI.COMMANDS.AGY, args, opts.onProgress);
-      if (stdout && stdout.trim()) return stdout.trim(); // Phase 3: future agy may fix -p
+      const direct = caps.outputFormatJson
+        ? parseAgyJsonResponse(stdout)
+        : stdout.trim() || undefined;
+      if (direct) return direct;
 
-      // Recover from the transcript: prefer an id we set, else discover it.
+      // 2) Opt-in PTY recovery: a TTY-only build prints under a pseudo-terminal.
+      if (ptyEnabled()) {
+        const ptyOut = await runAgyUnderPty(args, opts.onProgress);
+        const fromPty = caps.outputFormatJson
+          ? parseAgyJsonResponse(ptyOut)
+          : ptyOut.trim() || undefined;
+        if (fromPty) return fromPty;
+      }
+
+      // 3) Transcript recovery: prefer an id we set, else discover it.
       const id =
         explicitConversationId(opts) ??
         conversationIdForCwd(cwd) ??

--- a/src/backends/agyCapabilities.ts
+++ b/src/backends/agyCapabilities.ts
@@ -1,0 +1,127 @@
+import { spawn } from "child_process";
+import { CLI } from "../constants.js";
+import { resolveCommandForExecution } from "../utils/commandExecutor.js";
+import { Logger } from "../utils/logger.js";
+
+/**
+ * What the *installed* `agy` build supports, discovered from `agy --help` so the
+ * backend adapts to whatever version is on PATH instead of hard-coding 1.0.x
+ * assumptions. As upstream fixes print-mode (antigravity-cli#7) these flags
+ * appear and we automatically prefer the clean paths — JSON on stdout, a
+ * caller-known conversation id — over transcript scraping. That is Phase 3's
+ * "self-retiring fallback" in code: nothing here needs editing when agy improves.
+ *
+ * Detection is a best-effort scan of the help text. Every capability defaults to
+ * false, so a missing / slow / unusual `agy --help` leaves us behaving exactly as
+ * the Phase 1-2 backend did.
+ */
+export interface AgyCapabilities {
+  /** `--output-format` exists and advertises a json mode → we can skip scraping. */
+  outputFormatJson: boolean;
+  /** `--conversation <id>` exists → sessions can be addressed explicitly. */
+  conversationId: boolean;
+  /** `--continue`/`-c` exists → "resume latest" is available. */
+  continueFlag: boolean;
+  /** `--print-timeout` exists → headless runs can bound their own wait. */
+  printTimeout: boolean;
+  /** Raw help text, kept for diagnostics. */
+  raw: string;
+}
+
+export const NO_AGY_CAPABILITIES: AgyCapabilities = {
+  outputFormatJson: false,
+  conversationId: false,
+  continueFlag: false,
+  printTimeout: false,
+  raw: "",
+};
+
+/** Parse `agy --help` text into a capability set. Pure — unit tested directly. */
+export function parseAgyHelp(help: string): AgyCapabilities {
+  if (!help) return NO_AGY_CAPABILITIES;
+  const has = (re: RegExp) => re.test(help);
+  return {
+    outputFormatJson: has(/--output-format\b/) && /\bjson\b/i.test(help),
+    conversationId: has(/--conversation\b/),
+    continueFlag: has(/--continue\b/) || has(/(^|\s)-c\b/),
+    printTimeout: has(/--print-timeout\b/),
+    raw: help,
+  };
+}
+
+const HELP_TIMEOUT_MS = 4000;
+
+/** Run `agy --help` defensively: never throws, never hangs the backend. */
+function runAgyHelp(): Promise<string> {
+  return new Promise((resolve) => {
+    let cmd: string;
+    try {
+      cmd = resolveCommandForExecution(CLI.COMMANDS.AGY);
+    } catch {
+      resolve("");
+      return;
+    }
+    const isWindows = process.platform === "win32";
+    const spawnCmd = isWindows && /\s/.test(cmd) ? `"${cmd}"` : cmd;
+
+    let child;
+    try {
+      child = spawn(spawnCmd, ["--help"], {
+        env: process.env,
+        shell: isWindows,
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch {
+      resolve("");
+      return;
+    }
+
+    let out = "";
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(out);
+    };
+    // Some CLIs print usage to stderr; capture both.
+    child.stdout?.on("data", (d) => (out += d.toString()));
+    child.stderr?.on("data", (d) => (out += d.toString()));
+    child.on("error", () => finish());
+    child.on("close", () => finish());
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      finish();
+    }, HELP_TIMEOUT_MS);
+    timer.unref?.();
+  });
+}
+
+let cached: Promise<AgyCapabilities> | undefined;
+
+/**
+ * Probe (once per process) what the installed agy supports. Fail-safe: any
+ * problem yields NO_AGY_CAPABILITIES, i.e. the conservative Phase 1-2 behaviour.
+ */
+export function probeAgyCapabilities(): Promise<AgyCapabilities> {
+  if (!cached) {
+    cached = runAgyHelp()
+      .then(parseAgyHelp)
+      .catch((e) => {
+        Logger.warn(`agy: capability probe failed, assuming none: ${(e as Error).message}`);
+        return NO_AGY_CAPABILITIES;
+      });
+  }
+  return cached;
+}
+
+/** Test seam: pin a capability set (or pass nothing to clear the cache). */
+export function __setAgyCapabilitiesForTest(caps?: AgyCapabilities): void {
+  cached = caps ? Promise.resolve(caps) : undefined;
+}

--- a/src/backends/agyOutput.ts
+++ b/src/backends/agyOutput.ts
@@ -1,0 +1,162 @@
+import { spawn } from "child_process";
+import { CLI, ENV } from "../constants.js";
+import { resolveCommandForExecution } from "../utils/commandExecutor.js";
+import { extractReplies, type TranscriptEntry } from "./agyTranscript.js";
+
+/**
+ * Interprets `agy`'s *output channels* (as opposed to agyTranscript.ts, which
+ * reads its on-disk files). Two Phase 3 paths live here, both aimed at getting a
+ * real answer off stdout so the transcript scrape can retire:
+ *   1. parseAgyJsonResponse — read `agy --output-format json` cleanly.
+ *   2. runAgyUnderPty — coax a TTY-only build into actually printing, via a
+ *      pseudo-terminal, without touching any private files (S1b).
+ */
+
+/**
+ * Best-effort extraction of the model reply from `agy --output-format json`
+ * stdout. agy's JSON schema isn't documented yet, so we accept the shapes it is
+ * likely to emit and return undefined otherwise (the caller then tries plain
+ * stdout, then the transcript). Accepts a single object, JSONL, or a stream of
+ * transcript entries.
+ */
+export function parseAgyJsonResponse(stdout: string): string | undefined {
+  const trimmed = stdout.trim();
+  if (!trimmed) return undefined;
+
+  const candidates: unknown[] = [];
+  try {
+    candidates.push(JSON.parse(trimmed)); // single object / array
+  } catch {
+    for (const line of trimmed.split(/\r?\n/)) {
+      const l = line.trim();
+      if (!l) continue;
+      try {
+        candidates.push(JSON.parse(l)); // JSONL / stream-json
+      } catch {
+        /* not a JSON line */
+      }
+    }
+  }
+  if (!candidates.length) return undefined;
+
+  // Flatten one level so a top-level array of entries is handled too.
+  const flat = candidates.flatMap((c) => (Array.isArray(c) ? c : [c]));
+
+  // 1) Transcript-entry stream → reuse the one canonical extractor.
+  const entries = flat.filter(
+    (c): c is TranscriptEntry => !!c && typeof c === "object",
+  );
+  const fromEntries = extractReplies(entries);
+  if (fromEntries) return fromEntries;
+
+  // 2) A result object carrying the reply under a conventional field name.
+  const texts: string[] = [];
+  for (const c of flat) {
+    if (!c || typeof c !== "object") continue;
+    const o = c as Record<string, unknown>;
+    for (const k of ["response", "text", "content", "message", "output", "result"]) {
+      const v = o[k];
+      if (typeof v === "string" && v.trim()) {
+        texts.push(v.trim());
+        break;
+      }
+    }
+  }
+  const joined = texts.join("\n\n").trim();
+  return joined || undefined;
+}
+
+/** POSIX single-quote a token so it is inert inside an `sh -c` command string. */
+export function shSingleQuote(token: string): string {
+  return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Remove the `script(1)` banner lines and CRs so we keep only the child output. */
+export function stripScriptNoise(raw: string): string {
+  return raw
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "")
+    .split("\n")
+    .filter((line) => !/^Script (started|done)/.test(line))
+    .join("\n")
+    .trim();
+}
+
+/** Whether the opt-in PTY recovery path is enabled (AGY_MCP_PTY=1). */
+export function ptyEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env[ENV.AGY_PTY] || "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+const PTY_TIMEOUT_MS = 10 * 60 * 1000; // generous: large analyses can be slow
+
+/**
+ * Run `agy <args>` under a pseudo-terminal via the `script(1)` utility, so a build
+ * that only streams output to a TTY still gives us real stdout — recovering the
+ * answer without reading any of agy's private transcript files (Phase 3, S1b).
+ *
+ * Opt-in (AGY_MCP_PTY=1), POSIX-only, and best-effort: resolves to "" if `script`
+ * is missing or yields nothing, so the caller falls through to transcript
+ * recovery. The agy path and every arg are POSIX-quoted, preserving the
+ * shell-injection safety of the non-PTY path.
+ */
+export function runAgyUnderPty(
+  args: string[],
+  onProgress?: (newOutput: string) => void,
+): Promise<string> {
+  return new Promise((resolve) => {
+    if (process.platform === "win32") {
+      resolve(""); // no `script` PTY on Windows
+      return;
+    }
+    const agy = resolveCommandForExecution(CLI.COMMANDS.AGY);
+    const inner = [agy, ...args].map(shSingleQuote).join(" ");
+    // util-linux: `script -qec CMD FILE`; BSD/macOS: `script -q FILE CMD...`.
+    const scriptArgs =
+      process.platform === "darwin"
+        ? ["-q", "/dev/null", "/bin/sh", "-c", inner]
+        : ["-qec", inner, "/dev/null"];
+
+    let child;
+    try {
+      child = spawn("script", scriptArgs, {
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch {
+      resolve(""); // `script` not installed
+      return;
+    }
+
+    let out = "";
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(stripScriptNoise(out));
+    };
+    child.stdout?.on("data", (d) => {
+      const s = d.toString();
+      out += s;
+      onProgress?.(s);
+    });
+    child.on("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(""); // spawn failed → let the caller fall back
+    });
+    child.on("close", () => finish());
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      finish();
+    }, PTY_TIMEOUT_MS);
+    timer.unref?.();
+  });
+}

--- a/src/backends/agyTranscript.ts
+++ b/src/backends/agyTranscript.ts
@@ -28,6 +28,9 @@ const logsDir = (id: string) =>
   path.join(AGY_BASE, "brain", id, ".system_generated", "logs");
 const jsonlPath = (id: string) => path.join(logsDir(id), "transcript.jsonl");
 const brainDir = path.join(AGY_BASE, "brain");
+// agy 1.0.x dual-writes a SQLite `.db`; observed locations vary by build — either
+// alongside the JSONL in the logs dir, or under a separate conversations/ dir.
+const conversationDbPath = (id: string) => path.join(AGY_BASE, "conversations", `${id}.db`);
 
 export interface TranscriptEntry {
   source?: string;
@@ -109,14 +112,18 @@ function readJsonlResponse(id: string): string {
   return extractReplies(entries);
 }
 
-/** The first `.db` file in a conversation's logs dir, if any. */
+/** Locate the SQLite transcript for a conversation across known agy layouts. */
 function findSqlite(id: string): string | undefined {
+  // (a) alongside the JSONL in the logs dir...
   try {
     const file = readdirSync(logsDir(id)).find((f) => f.endsWith(".db"));
-    return file ? path.join(logsDir(id), file) : undefined;
+    if (file) return path.join(logsDir(id), file);
   } catch {
-    return undefined;
+    /* logs dir may not exist */
   }
+  // (b) ...or the separate conversations/<id>.db some builds use.
+  const conv = conversationDbPath(id);
+  return existsSync(conv) ? conv : undefined;
 }
 
 /**
@@ -188,8 +195,13 @@ function readSqliteResponse(dbPath: string): string {
  */
 export function readTranscriptResponse(id: string): string {
   if (existsSync(jsonlPath(id))) {
-    const text = readJsonlResponse(id);
-    if (text) return text;
+    try {
+      const text = readJsonlResponse(id);
+      if (text) return text;
+    } catch (e) {
+      // TOCTOU/permissions: fall through to the SQLite reader rather than throw.
+      Logger.warn(`agy: JSONL read failed for ${id}, trying SQLite: ${(e as Error).message}`);
+    }
   }
   const db = findSqlite(id);
   if (db) return readSqliteResponse(db);

--- a/src/backends/agyTranscript.ts
+++ b/src/backends/agyTranscript.ts
@@ -1,0 +1,200 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import os from "os";
+import path from "path";
+import { createRequire } from "module";
+import { Logger } from "../utils/logger.js";
+
+// node:sqlite has no ESM export on current Node; reach it via createRequire so
+// the lazy, guarded load below works under "type": "module".
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Recovers `agy` model replies from its on-disk transcript.
+ *
+ * Why this exists: `agy -p` (print mode) in 1.0.x returns exit 0 but writes
+ * nothing to stdout — the reply only lands in agy's own transcript files. This
+ * module is the deliberately-isolated "private contract" reader so the rest of
+ * the backend doesn't bake in agy's internal layout. See
+ * docs/migration/antigravity-cli.md (§1) for the full rationale and the upstream
+ * fix (antigravity-cli#7) that will let us delete it.
+ *
+ * agy 1.0.5 already dual-writes a `.db` alongside the `.jsonl`; when JSONL stops
+ * being generated we need the SQLite path. Both live behind readResponse().
+ */
+
+const AGY_BASE = path.join(os.homedir(), ".gemini", "antigravity-cli");
+const LAST_CONVERSATIONS = path.join(AGY_BASE, "cache", "last_conversations.json");
+const logsDir = (id: string) =>
+  path.join(AGY_BASE, "brain", id, ".system_generated", "logs");
+const jsonlPath = (id: string) => path.join(logsDir(id), "transcript.jsonl");
+const brainDir = path.join(AGY_BASE, "brain");
+
+export interface TranscriptEntry {
+  source?: string;
+  type?: string;
+  status?: string;
+  content?: string;
+}
+
+/** Map the current workspace directory to its most recent agy conversation id. */
+export function conversationIdForCwd(cwd: string): string | undefined {
+  try {
+    const map = JSON.parse(readFileSync(LAST_CONVERSATIONS, "utf8")) as Record<string, string>;
+    return map[cwd] ?? map[path.resolve(cwd)];
+  } catch (e) {
+    Logger.warn(`agy: could not read last_conversations.json: ${(e as Error).message}`);
+    return undefined;
+  }
+}
+
+/**
+ * Fallback discovery: the newest conversation directory whose logs were written
+ * at or after `sinceMs`. Bounding by start time stops us returning a stale reply
+ * from a previous run when last_conversations.json lookup misses or races.
+ */
+export function newestConversationSince(sinceMs: number): string | undefined {
+  let best: { id: string; mtime: number } | undefined;
+  let ids: string[];
+  try {
+    ids = readdirSync(brainDir);
+  } catch {
+    return undefined;
+  }
+  for (const id of ids) {
+    const dir = logsDir(id);
+    let mtime: number;
+    try {
+      mtime = statSync(dir).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (mtime + 1 < sinceMs) continue; // +1ms slack for coarse fs timestamps
+    if (!best || mtime > best.mtime) best = { id, mtime };
+  }
+  return best?.id;
+}
+
+/** Extract DONE planner replies that follow the last user input. */
+export function extractReplies(entries: TranscriptEntry[]): string {
+  let lastUserIdx = -1;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].type === "USER_INPUT") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  const replies = entries
+    .slice(lastUserIdx + 1)
+    .filter(
+      (e) =>
+        e.source === "MODEL" &&
+        e.type === "PLANNER_RESPONSE" &&
+        e.status === "DONE" &&
+        typeof e.content === "string",
+    )
+    .map((e) => e.content as string);
+  return replies.join("\n\n").trim();
+}
+
+function readJsonlResponse(id: string): string {
+  const lines = readFileSync(jsonlPath(id), "utf8").split(/\r?\n/).filter(Boolean);
+  const entries: TranscriptEntry[] = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line) as TranscriptEntry);
+    } catch {
+      /* skip malformed lines */
+    }
+  }
+  return extractReplies(entries);
+}
+
+/** The first `.db` file in a conversation's logs dir, if any. */
+function findSqlite(id: string): string | undefined {
+  try {
+    const file = readdirSync(logsDir(id)).find((f) => f.endsWith(".db"));
+    return file ? path.join(logsDir(id), file) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * SQLite reader for when agy drops JSONL in favour of its dual-written `.db`.
+ * The schema isn't publicly documented, so this is best-effort: it scans every
+ * table for rows that JSON-parse into transcript entries and reuses the same
+ * extraction. If `node:sqlite` is unavailable (Node < 22.5) or nothing parses,
+ * it throws an actionable error rather than returning a wrong answer.
+ */
+function readSqliteResponse(dbPath: string): string {
+  let DatabaseSync: new (p: string, opts?: object) => {
+    prepare(sql: string): { all(...params: unknown[]): Array<Record<string, unknown>> };
+    close(): void;
+  };
+  try {
+    // Lazy, guarded: node:sqlite is experimental and only present on newer Node.
+    ({ DatabaseSync } = nodeRequire("node:sqlite"));
+  } catch {
+    throw new Error(
+      `agy: transcript is SQLite-only (${dbPath}) but node:sqlite is unavailable. ` +
+        `Upgrade to Node >= 22.5, or wait for the agy '-p' stdout fix (antigravity-cli#7).`,
+    );
+  }
+
+  const db = new DatabaseSync(dbPath, { readOnly: true } as object);
+  try {
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+      .all()
+      .map((r) => String(r.name));
+
+    const entries: TranscriptEntry[] = [];
+    for (const table of tables) {
+      let rows: Array<Record<string, unknown>>;
+      try {
+        rows = db.prepare(`SELECT * FROM "${table}"`).all();
+      } catch {
+        continue;
+      }
+      for (const row of rows) {
+        for (const value of Object.values(row)) {
+          if (typeof value !== "string") continue;
+          try {
+            const parsed = JSON.parse(value) as TranscriptEntry;
+            if (parsed && (parsed.type || parsed.source)) entries.push(parsed);
+          } catch {
+            /* not a JSON cell */
+          }
+        }
+      }
+    }
+
+    const text = extractReplies(entries);
+    if (!text) {
+      throw new Error(
+        `agy: found a SQLite transcript (${dbPath}) but could not extract a model reply ` +
+          `from its schema. Please report this with the agy version (the schema is not yet public).`,
+      );
+    }
+    return text;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Read the model's reply for a conversation, preferring JSONL and falling back
+ * to SQLite. Throws with a clear message if neither yields a reply.
+ */
+export function readTranscriptResponse(id: string): string {
+  if (existsSync(jsonlPath(id))) {
+    const text = readJsonlResponse(id);
+    if (text) return text;
+  }
+  const db = findSqlite(id);
+  if (db) return readSqliteResponse(db);
+  throw new Error(
+    `agy: no model response found for conversation ${id} (looked for ` +
+      `${jsonlPath(id)} and a .db fallback).`,
+  );
+}

--- a/src/backends/gemini.ts
+++ b/src/backends/gemini.ts
@@ -1,0 +1,23 @@
+import { executeGeminiCLI } from "../utils/geminiExecutor.js";
+import type { Backend, BackendRunOptions } from "./types.js";
+
+/**
+ * Default backend: the Google Gemini CLI (`gemini`). It inlines `@file`
+ * references itself, honours `-m/--model`, and implements the Pro->Flash quota
+ * fallback inside executeGeminiCLI. Retired 2026-06-18 for free/Pro/Ultra tiers
+ * (see docs/migration/antigravity-cli.md), hence the pluggable seam.
+ */
+export const geminiBackend: Backend = {
+  name: "gemini",
+  supportsModelSelection: true,
+  sandboxIsolatesToolExecution: true,
+  run(prompt: string, opts: BackendRunOptions): Promise<string> {
+    return executeGeminiCLI(
+      prompt,
+      opts.model,
+      !!opts.sandbox,
+      !!opts.changeMode,
+      opts.onProgress,
+    );
+  },
+};

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -1,4 +1,4 @@
-import { ENV, MODELS } from "../constants.js";
+import { ENV, MODELS, RETIREMENT } from "../constants.js";
 import { Logger } from "../utils/logger.js";
 import type { Backend, BackendRunOptions } from "./types.js";
 import { geminiBackend } from "./gemini.js";
@@ -8,29 +8,80 @@ export type { Backend, BackendRunOptions } from "./types.js";
 export { geminiBackend } from "./gemini.js";
 export { agyBackend } from "./agy.js";
 
-/**
- * The default backend name. Stays "gemini" until the 2026-06-18 retirement —
- * flipping the migration's final switch (Phase 4) is a one-line change here.
- */
+/** Pre-retirement default backend name. */
 export const DEFAULT_BACKEND = "gemini";
 
+const RETIREMENT_MS = Date.parse(`${RETIREMENT.GEMINI_CLI_ISO}T00:00:00Z`);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
- * Select the active backend from GEMINI_MCP_BACKEND. Defaults to the Gemini CLI;
- * "agy"/"antigravity" selects the experimental Antigravity CLI backend.
+ * The default backend, resolved against the calendar (Phase 4 cutover): the
+ * Gemini CLI until it is retired on 2026-06-18, then `agy` automatically — because
+ * once gemini is gone, agy is the only live option. An explicit GEMINI_MCP_BACKEND
+ * always overrides this. `now` is injectable for tests.
  */
-export function getBackend(env: NodeJS.ProcessEnv = process.env): Backend {
-  const name = (env[ENV.BACKEND] || DEFAULT_BACKEND).trim().toLowerCase();
+export function resolveDefaultBackend(now: Date = new Date()): "gemini" | "agy" {
+  return now.getTime() >= RETIREMENT_MS ? "agy" : "gemini";
+}
+
+/**
+ * Select the active backend. GEMINI_MCP_BACKEND wins ("agy"/"antigravity" →
+ * Antigravity CLI, "gemini" → Gemini CLI); otherwise the date-aware default.
+ */
+export function getBackend(
+  env: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): Backend {
+  const explicit = (env[ENV.BACKEND] || "").trim().toLowerCase();
+  const name = explicit || resolveDefaultBackend(now);
   switch (name) {
     case "agy":
     case "antigravity":
       return agyBackend;
     case "gemini":
-    case "":
       return geminiBackend;
     default:
-      Logger.warn(`Unknown ${ENV.BACKEND}="${name}", falling back to ${DEFAULT_BACKEND}.`);
+      Logger.warn(`Unknown ${ENV.BACKEND}="${name}", falling back to gemini.`);
       return geminiBackend;
   }
+}
+
+// The approaching-retirement nudge is shown once per process, not on every call.
+let retirementNudged = false;
+
+/**
+ * Resolve the backend and any migration notices to surface to the caller:
+ *  - post-retirement, when the default has auto-flipped to agy;
+ *  - in the final countdown, a one-time nudge to test agy early.
+ * Both are suppressed when GEMINI_MCP_BACKEND is set explicitly.
+ */
+export function backendSelection(
+  env: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+): { backend: Backend; notices: string[] } {
+  const backend = getBackend(env, now);
+  const notices: string[] = [];
+  const explicit = (env[ENV.BACKEND] || "").trim();
+
+  if (!explicit) {
+    const daysLeft = Math.ceil((RETIREMENT_MS - now.getTime()) / DAY_MS);
+    if (backend.name === "agy") {
+      notices.push(
+        `Gemini CLI was retired on ${RETIREMENT.GEMINI_CLI_ISO}; defaulting to the Antigravity CLI (agy) backend. Set ${ENV.BACKEND}=gemini to override.`,
+      );
+    } else if (daysLeft <= RETIREMENT.WARN_WITHIN_DAYS && !retirementNudged) {
+      retirementNudged = true;
+      notices.push(
+        `Gemini CLI retires on ${RETIREMENT.GEMINI_CLI_ISO} (~${daysLeft} day(s) left); test the successor now with ${ENV.BACKEND}=agy.`,
+      );
+    }
+  }
+  return { backend, notices };
+}
+
+/** Test seam: reset the once-per-process retirement nudge. */
+export function __resetRetirementNudgeForTest(): void {
+  retirementNudged = false;
 }
 
 /**
@@ -46,8 +97,7 @@ export async function runWithBackend(
   prompt: string,
   opts: BackendRunOptions,
 ): Promise<{ text: string; notices: string[]; backend: string }> {
-  const backend = getBackend();
-  const notices: string[] = [];
+  const { backend, notices } = backendSelection();
   const effective: BackendRunOptions = { ...opts, onNotice: (m) => notices.push(m) };
 
   if (effective.model && !backend.supportsModelSelection) {

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -1,0 +1,73 @@
+import { ENV, MODELS } from "../constants.js";
+import { Logger } from "../utils/logger.js";
+import type { Backend, BackendRunOptions } from "./types.js";
+import { geminiBackend } from "./gemini.js";
+import { agyBackend } from "./agy.js";
+
+export type { Backend, BackendRunOptions } from "./types.js";
+export { geminiBackend } from "./gemini.js";
+export { agyBackend } from "./agy.js";
+
+/**
+ * The default backend name. Stays "gemini" until the 2026-06-18 retirement —
+ * flipping the migration's final switch (Phase 4) is a one-line change here.
+ */
+export const DEFAULT_BACKEND = "gemini";
+
+/**
+ * Select the active backend from GEMINI_MCP_BACKEND. Defaults to the Gemini CLI;
+ * "agy"/"antigravity" selects the experimental Antigravity CLI backend.
+ */
+export function getBackend(env: NodeJS.ProcessEnv = process.env): Backend {
+  const name = (env[ENV.BACKEND] || DEFAULT_BACKEND).trim().toLowerCase();
+  switch (name) {
+    case "agy":
+    case "antigravity":
+      return agyBackend;
+    case "gemini":
+    case "":
+      return geminiBackend;
+    default:
+      Logger.warn(`Unknown ${ENV.BACKEND}="${name}", falling back to ${DEFAULT_BACKEND}.`);
+      return geminiBackend;
+  }
+}
+
+/**
+ * Run a prompt through the active backend, applying capability gating so the
+ * caller never gets a silent behaviour change:
+ *  - if the backend can't honour `model`, the model is dropped and a notice
+ *    explains it (agy print-mode is Flash-only);
+ *  - if the backend can't isolate tool execution, a requested `sandbox` yields a
+ *    notice rather than a false sense of safety.
+ * Notices are returned alongside the text for the tool layer to surface.
+ */
+export async function runWithBackend(
+  prompt: string,
+  opts: BackendRunOptions,
+): Promise<{ text: string; notices: string[]; backend: string }> {
+  const backend = getBackend();
+  const notices: string[] = [];
+  const effective: BackendRunOptions = { ...opts, onNotice: (m) => notices.push(m) };
+
+  if (effective.model && !backend.supportsModelSelection) {
+    notices.push(
+      `Backend "${backend.name}" ignores model selection (print-mode is ${MODELS.AGY_PRINT_DEFAULT}-only); "${effective.model}" was not applied.`,
+    );
+    effective.model = undefined; // and skip the gemini-only quota fallback path
+  }
+  if (effective.sandbox && !backend.sandboxIsolatesToolExecution) {
+    notices.push(
+      `Backend "${backend.name}" does not isolate tool execution in headless mode; the sandbox request cannot be guaranteed.`,
+    );
+  }
+
+  const text = await backend.run(prompt, effective);
+  return { text, notices, backend: backend.name };
+}
+
+/** Prepend any capability notices to a response so changes are never silent. */
+export function withNotices(notices: string[], body: string): string {
+  if (!notices.length) return body;
+  return notices.map((n) => `⚠️ ${n}`).join("\n") + "\n\n" + body;
+}

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -1,0 +1,33 @@
+import type { ApprovalMode } from "../constants.js";
+
+/**
+ * Options a backend understands. Backends interpret these in their own terms
+ * (e.g. the gemini backend maps `resume` to `--resume`, the agy backend to
+ * `--conversation`/`--continue`); unsupported options are ignored.
+ */
+export interface BackendRunOptions {
+  model?: string;
+  sandbox?: boolean;
+  changeMode?: boolean;
+  approvalMode?: ApprovalMode;
+  sessionId?: string;
+  resume?: string;
+  onProgress?: (newOutput: string) => void;
+  /**
+   * Sink for human-facing notices the backend wants surfaced to the caller —
+   * e.g. "this backend is Flash-only" or "print-mode agy does not sandbox".
+   * The tool layer prepends these to the response so behavior changes are never
+   * silent. Backends should call it; the tool layer supplies it.
+   */
+  onNotice?: (message: string) => void;
+}
+
+/** A pluggable CLI backend that turns a prompt into model output. */
+export interface Backend {
+  readonly name: string;
+  /** Whether `model` selection is honoured (agy print-mode is Flash-only). */
+  readonly supportsModelSelection: boolean;
+  /** Whether tool execution is actually isolated when `sandbox` is requested. */
+  readonly sandboxIsolatesToolExecution: boolean;
+  run(prompt: string, options: BackendRunOptions): Promise<string>;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,21 @@ export const STATUS_MESSAGES = {
 export const MODELS = {
   PRO: "gemini-2.5-pro",
   FLASH: "gemini-2.5-flash",
+  // Antigravity CLI print-mode is hardcoded to Gemini 3.5 Flash (High). This is
+  // informational only — `agy -p` ignores `--model` (and hangs if forced).
+  AGY_PRINT_DEFAULT: "gemini-3.5-flash",
 } as const;
+
+// Approval modes. The Gemini CLI exposes a graded set via --approval-mode; the
+// Antigravity CLI only has "skip everything" (--dangerously-skip-permissions),
+// and even that is a no-op in print mode. Backends map these in their own terms.
+export const APPROVAL_MODES = {
+  DEFAULT: "default",
+  AUTO_EDIT: "auto_edit",
+  YOLO: "yolo",
+  PLAN: "plan",
+} as const;
+export type ApprovalMode = (typeof APPROVAL_MODES)[keyof typeof APPROVAL_MODES];
 
 // MCP Protocol Constants
 export const PROTOCOL = {
@@ -62,6 +76,7 @@ export const CLI = {
   // Command names
   COMMANDS: {
     GEMINI: "gemini",
+    AGY: "agy", // Antigravity CLI — gemini-cli's successor (retirement: 2026-06-18)
     ECHO: "echo",
   },
   // Command flags
@@ -83,6 +98,8 @@ export const CLI = {
 // Environment variables that configure the server.
 export const ENV = {
   GEMINI_CLI_PATH: "GEMINI_CLI_PATH", // explicit path to the gemini executable (Windows shim resolution)
+  AGY_CLI_PATH: "AGY_CLI_PATH", // explicit path to the agy (Antigravity CLI) executable
+  BACKEND: "GEMINI_MCP_BACKEND", // active CLI backend: "gemini" (default) | "agy"/"antigravity"
 } as const;
 
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,6 +100,16 @@ export const ENV = {
   GEMINI_CLI_PATH: "GEMINI_CLI_PATH", // explicit path to the gemini executable (Windows shim resolution)
   AGY_CLI_PATH: "AGY_CLI_PATH", // explicit path to the agy (Antigravity CLI) executable
   BACKEND: "GEMINI_MCP_BACKEND", // active CLI backend: "gemini" (default) | "agy"/"antigravity"
+  AGY_PTY: "AGY_MCP_PTY", // opt-in: recover agy -p stdout via a pseudo-terminal (POSIX only)
+} as const;
+
+// Migration milestones. Gemini CLI is retired for free/Pro/Ultra tiers on this
+// date; from then on `agy` (Antigravity CLI) is the only live option, so the
+// default backend flips to it automatically (Phase 4). Overridable via ENV.BACKEND.
+export const RETIREMENT = {
+  GEMINI_CLI_ISO: "2026-06-18",
+  // Days before retirement at which we start nudging callers to test agy.
+  WARN_WITHIN_DAYS: 14,
 } as const;
 
 

--- a/src/tools/ask-gemini.tool.ts
+++ b/src/tools/ask-gemini.tool.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { UnifiedTool } from './registry.js';
-import { executeGeminiCLI, processChangeModeOutput } from '../utils/geminiExecutor.js';
+import { processChangeModeOutput } from '../utils/geminiExecutor.js';
+import { runWithBackend, withNotices } from '../backends/index.js';
 import {
   ERROR_MESSAGES,
   STATUS_MESSAGES
@@ -39,22 +40,22 @@ export const askGeminiTool: UnifiedTool = {
       );
     }
 
-    const result = await executeGeminiCLI(
-      prompt as string,
-      model as string | undefined,
-      !!sandbox,
-      !!changeMode,
-      onProgress
-    );
+    const { text: result, notices } = await runWithBackend(prompt as string, {
+      model: model as string | undefined,
+      sandbox: !!sandbox,
+      changeMode: !!changeMode,
+      onProgress,
+    });
 
     if (changeMode) {
-      return processChangeModeOutput(
+      const processed = await processChangeModeOutput(
         result,
         args.chunkIndex as number | undefined,
         undefined,
         prompt as string
       );
+      return withNotices(notices, processed);
     }
-    return `${STATUS_MESSAGES.GEMINI_RESPONSE}\n${result}`; // changeMode false
+    return withNotices(notices, `${STATUS_MESSAGES.GEMINI_RESPONSE}\n${result}`); // changeMode false
   }
 };

--- a/src/tools/brainstorm.tool.ts
+++ b/src/tools/brainstorm.tool.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { UnifiedTool } from './registry.js';
 import { Logger } from '../utils/logger.js';
-import { executeGeminiCLI } from '../utils/geminiExecutor.js';
+import { runWithBackend, withNotices } from '../backends/index.js';
 
 export function buildBrainstormPrompt(config: {
   prompt: string;
@@ -165,7 +165,11 @@ export const brainstormTool: UnifiedTool = {
     // Report progress to user
     onProgress?.(`Generating ${ideaCount} ideas via ${methodology} methodology...`);
 
-    // Execute with Gemini
-    return await executeGeminiCLI(enhancedPrompt, model as string | undefined, false, false, onProgress);
+    // Execute via the active backend (gemini by default, agy when selected).
+    const { text, notices } = await runWithBackend(enhancedPrompt, {
+      model: model as string | undefined,
+      onProgress,
+    });
+    return withNotices(notices, text);
   }
 };

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -1,4 +1,7 @@
 import { spawn, execSync } from "child_process";
+import { existsSync } from "fs";
+import os from "os";
+import path from "path";
 import { Logger } from "./logger.js";
 import { CLI, ENV } from "../constants.js";
 
@@ -20,31 +23,60 @@ export function selectWindowsGeminiCandidate(candidates: string[], command: stri
 // often runs without the user's interactive PATH, so we (1) honour an explicit
 // GEMINI_CLI_PATH override, then (2) ask `where` and prefer shims that cmd.exe
 // can actually launch. PowerShell shims and extensionless shell scripts are not
-// selected as fallbacks. Resolution is cached per command for the life of the process.
-const resolveCache = new Map<string, string>();
-export function resolveCommandForExecution(command: string): string {
-  if (process.platform !== "win32" || command !== CLI.COMMANDS.GEMINI) return command;
-
-  const cached = resolveCache.get(command);
-  if (cached) return cached;
-
-  let resolved: string = command;
+// selected as fallbacks.
+function resolveGemini(command: string): string {
+  if (process.platform !== "win32") return command; // off-Windows: rely on PATH
   const override = process.env[ENV.GEMINI_CLI_PATH]?.trim();
-  if (override) {
-    resolved = override;
-  } else {
+  if (override) return override;
+  try {
+    const out = execSync(`where ${command}`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const candidates = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+    return selectWindowsGeminiCandidate(candidates, command);
+  } catch {
+    return `${command}.cmd`;
+  }
+}
+
+// Resolve the agy (Antigravity CLI) executable. Unlike gemini's npm shim, agy is
+// a Go binary the installer drops into ~/.local/bin (POSIX) or %LOCALAPPDATA%
+// (Windows) — directories the MCP server's PATH often doesn't include. So we
+// (1) honour AGY_CLI_PATH, then (2) probe known locations / `where`.
+function resolveAgy(command: string): string {
+  const override = process.env[ENV.AGY_CLI_PATH]?.trim();
+  if (override) return override;
+  if (process.platform === "win32") {
     try {
       const out = execSync(`where ${command}`, {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       });
       const candidates = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
-      resolved = selectWindowsGeminiCandidate(candidates, command);
+      const byExt = (ext: string) =>
+        candidates.find((c) => c.toLowerCase().endsWith(ext));
+      return byExt(".exe") || byExt(".cmd") || byExt(".bat") || candidates[0] || `${command}.exe`;
     } catch {
-      resolved = `${command}.cmd`;
+      return `${command}.exe`;
     }
   }
+  const localBin = path.join(os.homedir(), ".local", "bin", command);
+  if (existsSync(localBin)) return localBin;
+  return command;
+}
 
+// The MCP server often runs without the user's interactive PATH; resolve the
+// real executable per command and cache it for the life of the process.
+const resolveCache = new Map<string, string>();
+export function resolveCommandForExecution(command: string): string {
+  if (command !== CLI.COMMANDS.GEMINI && command !== CLI.COMMANDS.AGY) return command;
+
+  const cached = resolveCache.get(command);
+  if (cached) return cached;
+
+  const resolved =
+    command === CLI.COMMANDS.AGY ? resolveAgy(command) : resolveGemini(command);
   resolveCache.set(command, resolved);
   return resolved;
 }
@@ -64,6 +96,13 @@ export function buildEnoentErrorMessage(command: string): string {
       isWindows
         ? `• Or set ${ENV.GEMINI_CLI_PATH} to the full path of the gemini shim (e.g. C:\\path\\to\\gemini.cmd).`
         : `• Or set ${ENV.GEMINI_CLI_PATH} to the full path of the gemini executable.`,
+    );
+  } else if (command === CLI.COMMANDS.AGY) {
+    lines.push(
+      `• agy ships with Google Antigravity; install it from https://antigravity.google and authenticate once with \`agy -i\`.`,
+      isWindows
+        ? `• It installs to %LOCALAPPDATA%\\Antigravity\\; add that to PATH or set ${ENV.AGY_CLI_PATH} to the full path of agy.exe.`
+        : `• It installs to ~/.local/bin; add that to PATH or set ${ENV.AGY_CLI_PATH} to the full path of the agy binary.`,
     );
   }
   return lines.join("\n");

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -48,6 +48,13 @@ function resolveAgy(command: string): string {
   const override = process.env[ENV.AGY_CLI_PATH]?.trim();
   if (override) return override;
   if (process.platform === "win32") {
+    // The documented install dir (%LOCALAPPDATA%\Antigravity) is rarely on the
+    // MCP server's PATH, so probe it whenever `where` comes up empty.
+    const probeInstallDir = (): string | undefined => {
+      const base = process.env.LOCALAPPDATA;
+      const installed = base && path.join(base, "Antigravity", `${command}.exe`);
+      return installed && existsSync(installed) ? installed : undefined;
+    };
     try {
       const out = execSync(`where ${command}`, {
         encoding: "utf8",
@@ -56,9 +63,10 @@ function resolveAgy(command: string): string {
       const candidates = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
       const byExt = (ext: string) =>
         candidates.find((c) => c.toLowerCase().endsWith(ext));
-      return byExt(".exe") || byExt(".cmd") || byExt(".bat") || candidates[0] || `${command}.exe`;
+      return byExt(".exe") || byExt(".cmd") || byExt(".bat") || candidates[0] ||
+        probeInstallDir() || `${command}.exe`;
     } catch {
-      return `${command}.exe`;
+      return probeInstallDir() || `${command}.exe`;
     }
   }
   const localBin = path.join(os.homedir(), ".local", "bin", command);
@@ -108,11 +116,18 @@ export function buildEnoentErrorMessage(command: string): string {
   return lines.join("\n");
 }
 
+// A hung CLI must never wedge the long-lived MCP server: agy's print mode is
+// known to hang in some configurations, and the agy backend serializes calls
+// behind a queue, so one stuck child would block every later request. Large
+// analyses are documented to take up to ~15 minutes; default to a generous 20.
+export const COMMAND_TIMEOUT_MS = 20 * 60 * 1000;
+
 export async function executeCommand(
   command: string,
   args: string[],
   onProgress?: (newOutput: string) => void,
   stdinData?: string,
+  timeoutMs: number = COMMAND_TIMEOUT_MS,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const startTime = Date.now();
@@ -197,9 +212,26 @@ export async function executeCommand(
         Logger.error(`Gemini Quota Error: ${JSON.stringify(errorJson, null, 2)}`);
       }
     });
+    // Bound the run so a child that never exits cannot leak a pending promise
+    // for the life of the server. unref() keeps the timer from holding the
+    // event loop open; SIGKILL because a hung CLI may ignore SIGTERM.
+    const timer = setTimeout(() => {
+      if (isResolved) return;
+      isResolved = true;
+      Logger.error(`${command} timed out after ${Math.round(timeoutMs / 1000)}s; killing it.`);
+      try {
+        childProcess.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      reject(new Error(`${command} timed out after ${Math.round(timeoutMs / 1000)}s`));
+    }, timeoutMs);
+    timer.unref?.();
+
     childProcess.on("error", (error) => {
       if (isResolved) return;
       isResolved = true;
+      clearTimeout(timer);
       Logger.error(`Process error:`, error);
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ENOENT") {
@@ -211,6 +243,7 @@ export async function executeCommand(
     childProcess.on("close", (code) => {
       if (isResolved) return;
       isResolved = true;
+      clearTimeout(timer);
       if (code === 0) {
         Logger.commandComplete(startTime, code, stdout.length);
         resolve(stdout.trim());

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, realpathSync } from 'fs';
 import { executeCommand } from './commandExecutor.js';
 import { Logger } from './logger.js';
 import {
@@ -124,10 +124,29 @@ export function inlineFileReferences(prompt: string, root: string = process.cwd(
   // traversal references before we read anything from disk.
   assertSafeFileReferences(prompt, root);
   const normalizedRoot = path.resolve(root);
+  const escapesRoot = (p: string) =>
+    p !== normalizedRoot && !p.startsWith(normalizedRoot + path.sep);
   return prompt.replace(FILE_REF_PATTERN, (whole, ref: string) => {
     const resolved = path.resolve(normalizedRoot, ref);
+    // Symlink-aware guard: assertSafeFileReferences is lexical (path.resolve),
+    // so an in-root symlink could still point outside the root. Resolve the real
+    // target and re-check before reading. realpathSync throws on a missing path —
+    // that is handled below as "not found" (no contents leaked).
+    let real: string;
     try {
-      const content = readFileSync(resolved, 'utf8');
+      real = realpathSync(resolved);
+    } catch (e) {
+      Logger.warn(`inlineFileReferences: could not resolve @${ref}: ${(e as Error).message}`);
+      return `\n----- FILE NOT FOUND: ${ref} -----\n`;
+    }
+    if (escapesRoot(real)) {
+      throw new Error(
+        `Refusing @file reference resolving outside the project directory: "@${ref}". ` +
+        `Only files within ${normalizedRoot} may be referenced.`
+      );
+    }
+    try {
+      const content = readFileSync(real, 'utf8');
       return `\n----- BEGIN FILE: ${ref} -----\n${content}\n----- END FILE: ${ref} -----\n`;
     } catch (e) {
       Logger.warn(`inlineFileReferences: could not read @${ref}: ${(e as Error).message}`);

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -28,16 +28,39 @@ const FILE_REF_PATTERN = /@(\S+)/g;
  */
 export function assertSafeFileReferences(prompt: string, root: string = process.cwd()): void {
   const normalizedRoot = path.resolve(root);
+  // Canonicalize the root once so a symlinked root (e.g. /tmp -> /private/tmp
+  // on macOS) doesn't make legitimate in-root targets look like escapes.
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(normalizedRoot);
+  } catch {
+    realRoot = normalizedRoot;
+  }
+  const escapes = (p: string, base: string) =>
+    p !== base && !p.startsWith(base + path.sep);
   for (const match of prompt.matchAll(FILE_REF_PATTERN)) {
     const ref = match[1];
     const resolved = path.resolve(normalizedRoot, ref);
-    const escapesRoot =
-      resolved !== normalizedRoot && !resolved.startsWith(normalizedRoot + path.sep);
     // `~` is rejected explicitly: path.resolve treats it as a literal segment,
     // so a home-directory reference would otherwise look contained.
-    if (ref.startsWith('~') || escapesRoot) {
+    if (ref.startsWith('~') || escapes(resolved, normalizedRoot)) {
       throw new Error(
         `Refusing @file reference outside the project directory: "@${ref}". ` +
+        `Only files within ${normalizedRoot} may be referenced.`
+      );
+    }
+    // Symlink-aware re-check: the lexical test above cannot see through an
+    // in-root symlink whose target lies outside the root. A path that doesn't
+    // resolve is fine here — nothing is read, and the CLI reports it.
+    let real: string | undefined;
+    try {
+      real = realpathSync(resolved);
+    } catch {
+      real = undefined;
+    }
+    if (real !== undefined && escapes(real, realRoot)) {
+      throw new Error(
+        `Refusing @file reference resolving outside the project directory: "@${ref}". ` +
         `Only files within ${normalizedRoot} may be referenced.`
       );
     }
@@ -113,6 +136,15 @@ ${userRequest}
 }
 
 /**
+ * changeMode preprocessing shared by both backends: rewrite `file:foo` -> `@foo`
+ * so the inlining/guard path treats them as file refs, then wrap the request in
+ * the OLD/NEW template. One implementation so gemini and agy cannot drift.
+ */
+export function prepareChangeModePrompt(prompt: string): string {
+  return buildChangeModePrompt(prompt.replace(/file:(\S+)/g, '@$1'));
+}
+
+/**
  * Replaces every in-project `@path` reference with the file's contents inlined
  * in a delimited block. The Gemini CLI does this inlining itself; the agy
  * backend does NOT reliably inline `@file` (it is agent-first and decides to
@@ -120,12 +152,20 @@ ${userRequest}
  * determinism and the CVE-2026-0755 project-root guard in the data path.
  */
 export function inlineFileReferences(prompt: string, root: string = process.cwd()): string {
-  // Reuse the same guard the gemini path relies on; rejects ~, absolute and
-  // traversal references before we read anything from disk.
+  // Reuse the same guard the gemini path relies on; rejects ~, absolute,
+  // traversal and out-of-root-symlink references before we read anything.
   assertSafeFileReferences(prompt, root);
   const normalizedRoot = path.resolve(root);
+  // Compare real targets against the canonicalized root (see the note in
+  // assertSafeFileReferences about symlinked roots).
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(normalizedRoot);
+  } catch {
+    realRoot = normalizedRoot;
+  }
   const escapesRoot = (p: string) =>
-    p !== normalizedRoot && !p.startsWith(normalizedRoot + path.sep);
+    p !== realRoot && !p.startsWith(realRoot + path.sep);
   return prompt.replace(FILE_REF_PATTERN, (whole, ref: string) => {
     const resolved = path.resolve(normalizedRoot, ref);
     // Symlink-aware guard: assertSafeFileReferences is lexical (path.resolve),
@@ -167,8 +207,7 @@ export async function executeGeminiCLI(
   let prompt_processed = prompt;
 
   if (changeMode) {
-    // file:foo -> @foo so the inlining/guard path treats them as file refs.
-    prompt_processed = buildChangeModePrompt(prompt.replace(/file:(\S+)/g, '@$1'));
+    prompt_processed = prepareChangeModePrompt(prompt);
   }
 
   // Block @file references that escape the project root before the prompt

--- a/src/utils/geminiExecutor.ts
+++ b/src/utils/geminiExecutor.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { readFileSync } from 'fs';
 import { executeCommand } from './commandExecutor.js';
 import { Logger } from './logger.js';
 import {
@@ -43,19 +44,13 @@ export function assertSafeFileReferences(prompt: string, root: string = process.
   }
 }
 
-export async function executeGeminiCLI(
-  prompt: string,
-  model?: string,
-  sandbox?: boolean,
-  changeMode?: boolean,
-  onProgress?: (newOutput: string) => void
-): Promise<string> {
-  let prompt_processed = prompt;
-
-  if (changeMode) {
-    prompt_processed = prompt.replace(/file:(\S+)/g, '@$1');
-
-    const changeModeInstructions = `
+/**
+ * Wraps a user request in the changeMode instruction template that makes the
+ * model emit machine-applicable OLD/NEW edit blocks. The format is model- and
+ * CLI-agnostic, so both the gemini and agy backends share this builder.
+ */
+export function buildChangeModePrompt(userRequest: string): string {
+  return `
 [CHANGEMODE INSTRUCTIONS]
 You are generating code modifications that will be processed by an automated system. The output format is critical because it enables programmatic application of changes without human intervention.
 
@@ -113,9 +108,48 @@ NEW:
 IMPORTANT: The OLD section must be an EXACT copy from the file that can be found with Ctrl+F!
 
 USER REQUEST:
-${prompt_processed}
+${userRequest}
 `;
-    prompt_processed = changeModeInstructions;
+}
+
+/**
+ * Replaces every in-project `@path` reference with the file's contents inlined
+ * in a delimited block. The Gemini CLI does this inlining itself; the agy
+ * backend does NOT reliably inline `@file` (it is agent-first and decides to
+ * read files via its own tools), so for agy we inline ourselves to keep both
+ * determinism and the CVE-2026-0755 project-root guard in the data path.
+ */
+export function inlineFileReferences(prompt: string, root: string = process.cwd()): string {
+  // Reuse the same guard the gemini path relies on; rejects ~, absolute and
+  // traversal references before we read anything from disk.
+  assertSafeFileReferences(prompt, root);
+  const normalizedRoot = path.resolve(root);
+  return prompt.replace(FILE_REF_PATTERN, (whole, ref: string) => {
+    const resolved = path.resolve(normalizedRoot, ref);
+    try {
+      const content = readFileSync(resolved, 'utf8');
+      return `\n----- BEGIN FILE: ${ref} -----\n${content}\n----- END FILE: ${ref} -----\n`;
+    } catch (e) {
+      Logger.warn(`inlineFileReferences: could not read @${ref}: ${(e as Error).message}`);
+      // Leave a visible marker rather than the raw token so the model isn't
+      // misled into thinking a file was provided.
+      return `\n----- FILE NOT FOUND: ${ref} -----\n`;
+    }
+  });
+}
+
+export async function executeGeminiCLI(
+  prompt: string,
+  model?: string,
+  sandbox?: boolean,
+  changeMode?: boolean,
+  onProgress?: (newOutput: string) => void
+): Promise<string> {
+  let prompt_processed = prompt;
+
+  if (changeMode) {
+    // file:foo -> @foo so the inlining/guard path treats them as file refs.
+    prompt_processed = buildChangeModePrompt(prompt.replace(/file:(\S+)/g, '@$1'));
   }
 
   // Block @file references that escape the project root before the prompt

--- a/test/unit/backends/agy.test.ts
+++ b/test/unit/backends/agy.test.ts
@@ -1,0 +1,69 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { buildAgyArgs, buildAgyPrompt } from "../../../src/backends/agy.js";
+import { extractReplies } from "../../../src/backends/agyTranscript.js";
+import { APPROVAL_MODES } from "../../../src/constants.js";
+
+describe("Backends: agy arg building", () => {
+  test("emits no session/model flags for a plain prompt (model is never forwarded)", () => {
+    assert.deepEqual(buildAgyArgs({ model: "gemini-2.5-pro" }), []);
+  });
+
+  test("maps resume='latest' to --continue and a specific id to --conversation", () => {
+    assert.deepEqual(buildAgyArgs({ resume: "latest" }), ["--continue"]);
+    assert.deepEqual(buildAgyArgs({ resume: "abc123" }), ["--conversation", "abc123"]);
+  });
+
+  test("uses --conversation for an explicit sessionId", () => {
+    assert.deepEqual(buildAgyArgs({ sessionId: "sess-1" }), ["--conversation", "sess-1"]);
+  });
+
+  test("forwards --sandbox and maps only yolo to --dangerously-skip-permissions", () => {
+    assert.deepEqual(buildAgyArgs({ sandbox: true }), ["--sandbox"]);
+    assert.deepEqual(buildAgyArgs({ approvalMode: APPROVAL_MODES.YOLO }), [
+      "--dangerously-skip-permissions",
+    ]);
+    assert.deepEqual(buildAgyArgs({ approvalMode: APPROVAL_MODES.PLAN }), []);
+  });
+});
+
+describe("Backends: agy prompt building", () => {
+  test("inlines in-project @file references itself (agy does not)", () => {
+    const out = buildAgyPrompt("summarise @package.json", {});
+    assert.match(out, /BEGIN FILE: package\.json/);
+    assert.match(out, /"name": "gemini-mcp-tool"/);
+    assert.doesNotMatch(out, /@package\.json/); // token replaced by contents
+  });
+
+  test("keeps the project-root guard when inlining", () => {
+    assert.throws(() => buildAgyPrompt("read @../secret", {}), /outside the project directory/);
+  });
+
+  test("wraps changeMode requests in the OLD/NEW template", () => {
+    const out = buildAgyPrompt("rename foo", { changeMode: true });
+    assert.match(out, /\[CHANGEMODE INSTRUCTIONS\]/);
+    assert.match(out, /USER REQUEST:/);
+  });
+});
+
+describe("Backends: agy transcript extraction", () => {
+  test("returns DONE planner replies after the last user input", () => {
+    const entries = [
+      { type: "USER_INPUT", content: "old turn" },
+      { source: "MODEL", type: "PLANNER_RESPONSE", status: "DONE", content: "stale" },
+      { type: "USER_INPUT", content: "current turn" },
+      { source: "MODEL", type: "PLANNER_RESPONSE", status: "IN_PROGRESS", content: "partial" },
+      { source: "MODEL", type: "PLANNER_RESPONSE", status: "DONE", content: "the answer" },
+    ];
+    assert.equal(extractReplies(entries), "the answer");
+  });
+
+  test("ignores non-model and non-done entries", () => {
+    const entries = [
+      { type: "USER_INPUT", content: "q" },
+      { source: "TOOL", type: "PLANNER_RESPONSE", status: "DONE", content: "tool noise" },
+      { source: "MODEL", type: "OTHER", status: "DONE", content: "wrong type" },
+    ];
+    assert.equal(extractReplies(entries), "");
+  });
+});

--- a/test/unit/backends/agyOutput.test.ts
+++ b/test/unit/backends/agyOutput.test.ts
@@ -1,0 +1,88 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { parseAgyHelp, NO_AGY_CAPABILITIES } from "../../../src/backends/agyCapabilities.js";
+import {
+  parseAgyJsonResponse,
+  shSingleQuote,
+  stripScriptNoise,
+  ptyEnabled,
+} from "../../../src/backends/agyOutput.js";
+
+describe("Backends: agy capability probing (Phase 3)", () => {
+  test("detects flags advertised by `agy --help`", () => {
+    const help = [
+      "Usage: agy [options]",
+      "  -p, --prompt <text>      run a one-shot prompt",
+      "  --output-format <fmt>    output format: text, json",
+      "  --conversation <id>      resume a specific conversation",
+      "  -c, --continue           continue the most recent conversation",
+      "  --print-timeout <ms>     bound a headless run",
+    ].join("\n");
+    const caps = parseAgyHelp(help);
+    assert.equal(caps.outputFormatJson, true);
+    assert.equal(caps.conversationId, true);
+    assert.equal(caps.continueFlag, true);
+    assert.equal(caps.printTimeout, true);
+  });
+
+  test("a 1.0.x help with no json mode yields the conservative defaults", () => {
+    const caps = parseAgyHelp("Usage: agy\n  -p, --prompt <text>\n  -i  interactive login");
+    assert.equal(caps.outputFormatJson, false);
+    assert.equal(caps.printTimeout, false);
+  });
+
+  test("empty help is treated as no capabilities", () => {
+    assert.deepEqual(parseAgyHelp(""), NO_AGY_CAPABILITIES);
+  });
+});
+
+describe("Backends: agy JSON stdout parsing (Phase 3)", () => {
+  test("reads a single result object's conventional reply field", () => {
+    assert.equal(parseAgyJsonResponse('{"response":"hello world"}'), "hello world");
+    assert.equal(parseAgyJsonResponse('{"text":"  spaced  "}'), "spaced");
+  });
+
+  test("reads a JSONL/stream of transcript entries via the canonical extractor", () => {
+    const stream = [
+      '{"type":"USER_INPUT","content":"q"}',
+      '{"source":"MODEL","type":"PLANNER_RESPONSE","status":"IN_PROGRESS","content":"part"}',
+      '{"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","content":"the answer"}',
+    ].join("\n");
+    assert.equal(parseAgyJsonResponse(stream), "the answer");
+  });
+
+  test("handles a top-level array of entries", () => {
+    const arr = JSON.stringify([
+      { type: "USER_INPUT", content: "q" },
+      { source: "MODEL", type: "PLANNER_RESPONSE", status: "DONE", content: "arr answer" },
+    ]);
+    assert.equal(parseAgyJsonResponse(arr), "arr answer");
+  });
+
+  test("returns undefined for empty or non-JSON stdout", () => {
+    assert.equal(parseAgyJsonResponse(""), undefined);
+    assert.equal(parseAgyJsonResponse("not json at all"), undefined);
+  });
+});
+
+describe("Backends: PTY helpers (Phase 3, S1b)", () => {
+  test("shSingleQuote makes injection metacharacters inert", () => {
+    assert.equal(shSingleQuote("plain"), "'plain'");
+    // an embedded single quote is closed, escaped, and reopened
+    assert.equal(shSingleQuote("a'b"), "'a'\\''b'");
+    // metacharacters survive literally inside the quotes
+    assert.equal(shSingleQuote("a; rm -rf /"), "'a; rm -rf /'");
+  });
+
+  test("stripScriptNoise drops the script(1) banners and CRs", () => {
+    const raw = "Script started, file is /dev/null\r\nthe answer\r\nScript done, file is /dev/null\r\n";
+    assert.equal(stripScriptNoise(raw), "the answer");
+  });
+
+  test("ptyEnabled is opt-in via AGY_MCP_PTY", () => {
+    assert.equal(ptyEnabled({}), false);
+    assert.equal(ptyEnabled({ AGY_MCP_PTY: "1" }), true);
+    assert.equal(ptyEnabled({ AGY_MCP_PTY: "true" }), true);
+    assert.equal(ptyEnabled({ AGY_MCP_PTY: "0" }), false);
+  });
+});

--- a/test/unit/backends/index.test.ts
+++ b/test/unit/backends/index.test.ts
@@ -1,0 +1,46 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  getBackend,
+  geminiBackend,
+  agyBackend,
+  withNotices,
+  DEFAULT_BACKEND,
+} from "../../../src/backends/index.js";
+
+describe("Backends: selection", () => {
+  test("defaults to the gemini backend", () => {
+    assert.equal(DEFAULT_BACKEND, "gemini");
+    assert.equal(getBackend({}).name, "gemini");
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "" }).name, "gemini");
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "gemini" }), geminiBackend);
+  });
+
+  test("selects agy for agy/antigravity (case/space-insensitive)", () => {
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "agy" }), agyBackend);
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: " Antigravity " }), agyBackend);
+  });
+
+  test("unknown backend names fall back to gemini", () => {
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "bogus" }).name, "gemini");
+  });
+
+  test("capability flags reflect each CLI's reality", () => {
+    assert.equal(geminiBackend.supportsModelSelection, true);
+    assert.equal(geminiBackend.sandboxIsolatesToolExecution, true);
+    // agy print-mode is Flash-only and does not isolate tool execution.
+    assert.equal(agyBackend.supportsModelSelection, false);
+    assert.equal(agyBackend.sandboxIsolatesToolExecution, false);
+  });
+});
+
+describe("Backends: withNotices", () => {
+  test("returns the body unchanged when there are no notices", () => {
+    assert.equal(withNotices([], "hello"), "hello");
+  });
+
+  test("prepends each notice with a warning marker", () => {
+    const out = withNotices(["a", "b"], "body");
+    assert.equal(out, "⚠️ a\n⚠️ b\n\nbody");
+  });
+});

--- a/test/unit/backends/index.test.ts
+++ b/test/unit/backends/index.test.ts
@@ -6,23 +6,58 @@ import {
   agyBackend,
   withNotices,
   DEFAULT_BACKEND,
+  resolveDefaultBackend,
+  backendSelection,
+  __resetRetirementNudgeForTest,
 } from "../../../src/backends/index.js";
 
+const BEFORE = new Date("2026-06-01T00:00:00Z"); // before the 2026-06-18 retirement
+const AFTER = new Date("2026-07-01T00:00:00Z"); // after it
+
 describe("Backends: selection", () => {
-  test("defaults to the gemini backend", () => {
+  test("defaults to the gemini backend before retirement", () => {
     assert.equal(DEFAULT_BACKEND, "gemini");
-    assert.equal(getBackend({}).name, "gemini");
-    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "" }).name, "gemini");
-    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "gemini" }), geminiBackend);
+    assert.equal(getBackend({}, BEFORE).name, "gemini");
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "" }, BEFORE).name, "gemini");
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "gemini" }, BEFORE), geminiBackend);
   });
 
   test("selects agy for agy/antigravity (case/space-insensitive)", () => {
-    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "agy" }), agyBackend);
-    assert.equal(getBackend({ GEMINI_MCP_BACKEND: " Antigravity " }), agyBackend);
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "agy" }, BEFORE), agyBackend);
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: " Antigravity " }, BEFORE), agyBackend);
   });
 
   test("unknown backend names fall back to gemini", () => {
-    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "bogus" }).name, "gemini");
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "bogus" }, BEFORE).name, "gemini");
+  });
+
+  test("Phase 4: default flips to agy on/after the retirement date", () => {
+    assert.equal(resolveDefaultBackend(BEFORE), "gemini");
+    assert.equal(resolveDefaultBackend(AFTER), "agy");
+    assert.equal(getBackend({}, AFTER), agyBackend);
+    // An explicit override still wins after retirement.
+    assert.equal(getBackend({ GEMINI_MCP_BACKEND: "gemini" }, AFTER), geminiBackend);
+  });
+
+  test("backendSelection surfaces the post-retirement auto-switch notice", () => {
+    __resetRetirementNudgeForTest();
+    const { backend, notices } = backendSelection({}, AFTER);
+    assert.equal(backend, agyBackend);
+    assert.equal(notices.length, 1);
+    assert.match(notices[0], /retired on 2026-06-18/);
+    // No notice when the backend was chosen explicitly.
+    assert.deepEqual(backendSelection({ GEMINI_MCP_BACKEND: "agy" }, AFTER).notices, []);
+  });
+
+  test("backendSelection nudges once in the final countdown, then stays quiet", () => {
+    __resetRetirementNudgeForTest();
+    const soon = new Date("2026-06-10T00:00:00Z"); // within WARN_WITHIN_DAYS
+    const first = backendSelection({}, soon);
+    assert.equal(first.backend, geminiBackend);
+    assert.equal(first.notices.length, 1);
+    assert.match(first.notices[0], /retires on 2026-06-18/);
+    // Once per process: the second call is silent.
+    assert.deepEqual(backendSelection({}, soon).notices, []);
   });
 
   test("capability flags reflect each CLI's reality", () => {

--- a/test/unit/utils/commandExecutor.test.ts
+++ b/test/unit/utils/commandExecutor.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCommandForExecution,
   buildEnoentErrorMessage,
   selectWindowsGeminiCandidate,
+  executeCommand,
 } from "../../../src/utils/commandExecutor.js";
 
 describe("Node Utilities: Command Executor & Quoting", () => {
@@ -58,5 +59,25 @@ describe("Node Utilities: Command Executor & Quoting", () => {
     const msg = buildEnoentErrorMessage("agy");
     assert.match(msg, /Could not find the "agy"/);
     assert.doesNotMatch(msg, /@google\/gemini-cli/);
+  });
+
+  test("executeCommand kills and rejects a child that outlives the timeout", async () => {
+    // A child that would run for 30s, bounded to 200ms. Without the timeout a
+    // hung CLI would leave this promise (and the agy queue) pending forever.
+    await assert.rejects(
+      executeCommand(
+        process.execPath,
+        ["-e", "setTimeout(() => {}, 30000)"],
+        undefined,
+        undefined,
+        200,
+      ),
+      /timed out after/,
+    );
+  });
+
+  test("executeCommand resolves trimmed stdout well within the default timeout", async () => {
+    const out = await executeCommand(process.execPath, ["-e", "console.log('  ok  ')"]);
+    assert.equal(out, "ok");
   });
 });

--- a/test/unit/utils/geminiExecutor.test.ts
+++ b/test/unit/utils/geminiExecutor.test.ts
@@ -7,6 +7,7 @@ import {
   assertSafeFileReferences,
   buildChangeModePrompt,
   inlineFileReferences,
+  prepareChangeModePrompt,
 } from "../../../src/utils/geminiExecutor.js";
 
 const root = process.cwd();
@@ -29,6 +30,39 @@ describe("Node Utilities: Gemini CLI Executor", () => {
     assert.match(out, /\[CHANGEMODE INSTRUCTIONS\]/);
     assert.match(out, /USER REQUEST:\ndo the thing/);
   });
+
+  test("prepareChangeModePrompt rewrites file: refs to @ refs before wrapping", () => {
+    const out = prepareChangeModePrompt("update file:src/index.ts please");
+    assert.match(out, /\[CHANGEMODE INSTRUCTIONS\]/);
+    assert.match(out, /@src\/index\.ts/);
+    assert.doesNotMatch(out, /file:src\/index\.ts/);
+  });
+
+  test(
+    "assertSafeFileReferences blocks an in-root symlink whose target escapes the root",
+    { skip: process.platform === "win32" }, // symlink creation needs privileges on Windows
+    () => {
+      const dir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "gem-root-")));
+      const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), "gem-secret-")));
+      try {
+        const secret = path.join(outside, "secret.txt");
+        writeFileSync(secret, "TOPSECRET");
+        symlinkSync(secret, path.join(dir, "link.txt"));
+        // Lexically in-root, but resolves outside — the gemini CLI would inline
+        // it, so the guard itself must refuse (CVE-2026-0755).
+        assert.throws(
+          () => assertSafeFileReferences("read @link.txt", dir),
+          /outside the project directory/,
+        );
+        // A regular in-root file is still fine.
+        writeFileSync(path.join(dir, "ok.txt"), "fine");
+        assert.doesNotThrow(() => assertSafeFileReferences("read @ok.txt", dir));
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+        rmSync(outside, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("inlineFileReferences replaces in-project refs with file contents", () => {
     const out = inlineFileReferences("see @package.json", root);

--- a/test/unit/utils/geminiExecutor.test.ts
+++ b/test/unit/utils/geminiExecutor.test.ts
@@ -1,5 +1,8 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   assertSafeFileReferences,
   buildChangeModePrompt,
@@ -42,5 +45,29 @@ describe("Node Utilities: Gemini CLI Executor", () => {
     const out = inlineFileReferences("@does-not-exist.txt", root);
     assert.match(out, /FILE NOT FOUND: does-not-exist\.txt/);
   });
+
+  test(
+    "inlineFileReferences blocks an in-root symlink whose target escapes the root",
+    { skip: process.platform === "win32" }, // symlink creation needs privileges on Windows
+    () => {
+      // realpath the temp roots so the guard's lexical normalizedRoot matches
+      // the symlink target's canonical path (macOS /var -> /private/var).
+      const dir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "agy-root-")));
+      const outside = realpathSync(mkdtempSync(path.join(os.tmpdir(), "agy-secret-")));
+      try {
+        const secret = path.join(outside, "secret.txt");
+        writeFileSync(secret, "TOPSECRET");
+        symlinkSync(secret, path.join(dir, "link.txt"));
+        // Lexically in-root, but resolves outside — must be refused, not inlined.
+        assert.throws(
+          () => inlineFileReferences("read @link.txt", dir),
+          /outside the project directory/,
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+        rmSync(outside, { recursive: true, force: true });
+      }
+    },
+  );
 });
 

--- a/test/unit/utils/geminiExecutor.test.ts
+++ b/test/unit/utils/geminiExecutor.test.ts
@@ -1,6 +1,10 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { assertSafeFileReferences } from "../../../src/utils/geminiExecutor.js";
+import {
+  assertSafeFileReferences,
+  buildChangeModePrompt,
+  inlineFileReferences,
+} from "../../../src/utils/geminiExecutor.js";
 
 const root = process.cwd();
 
@@ -15,6 +19,28 @@ describe("Node Utilities: Gemini CLI Executor", () => {
     assert.throws(() => assertSafeFileReferences("@../secret.txt", root), /outside the project directory/);
     assert.throws(() => assertSafeFileReferences("@~/.ssh/id_rsa", root), /outside the project directory/);
     assert.throws(() => assertSafeFileReferences("@/etc/passwd", root), /outside the project directory/);
+  });
+
+  test("buildChangeModePrompt wraps the request in the OLD/NEW template", () => {
+    const out = buildChangeModePrompt("do the thing");
+    assert.match(out, /\[CHANGEMODE INSTRUCTIONS\]/);
+    assert.match(out, /USER REQUEST:\ndo the thing/);
+  });
+
+  test("inlineFileReferences replaces in-project refs with file contents", () => {
+    const out = inlineFileReferences("see @package.json", root);
+    assert.match(out, /BEGIN FILE: package\.json/);
+    assert.match(out, /gemini-mcp-tool/);
+    assert.doesNotMatch(out, /@package\.json/);
+  });
+
+  test("inlineFileReferences enforces the same project-root guard before reading", () => {
+    assert.throws(() => inlineFileReferences("@/etc/passwd", root), /outside the project directory/);
+  });
+
+  test("inlineFileReferences marks missing files instead of leaking the token", () => {
+    const out = inlineFileReferences("@does-not-exist.txt", root);
+    assert.match(out, /FILE NOT FOUND: does-not-exist\.txt/);
   });
 });
 


### PR DESCRIPTION
## Summary

My migration off the Gemini CLI before Google retires it on **2026-06-18** (free/Pro/Ultra tiers). Two parts:

1. **`docs/migration/antigravity-cli.md`** — a deep-dive comparison of `gemini` vs `agy` for a non-interactive caller, with a phased plan.
2. **A pluggable backend layer** (`src/backends/`) implementing all the phases: the tool keeps working on `gemini` today and switches to `agy` automatically at retirement (or via one env var now).

Solved **ourselves** — the `agy` backend talks to `agy`'s real, observable behaviour (its `--help`, stdout, and on-disk files); nothing is imported from any third-party wrapper. Companion to discussion #90.

## The differences that bite a non-interactive caller — and how I handled them

- **`agy -p` writes nothing to stdout in 1.0.x** (non-TTY/headless/Windows). → Phase 3 makes output recovery a **capability-aware, self-retiring ladder**: clean JSON stdout → plain stdout → opt-in PTY → transcript (details below).
- **Print mode is Flash-only** (`--model` ignored, hangs `-p`). → model selection is capability-gated: on `agy` we drop the `model` arg, skip the now-meaningless Pro→Flash fallback, and emit a notice.
- **`@file` isn't inlined by `agy`**. → `inlineFileReferences()` reads the files ourselves, preserving determinism **and** the CVE-2026-0755 project-root guard (with a `realpathSync` symlink re-check).
- **Sandbox/approval are weaker than they look** (`--dangerously-skip-permissions` is a no-op in `-p`). → requesting `sandbox` on `agy` returns a clear notice instead of implying isolation.
- **Packaging/auth differ** (Go binary in `~/.local/bin`, auth via `agy -i`). → backend-aware executable resolution (`AGY_CLI_PATH`) and `agy`-correct ENOENT guidance.

## Implemented (by phase)

- **Phase 0 ✅** Backend seam: `Backend` interface, `getBackend()`, `runWithBackend()`, capability flags; `ask-gemini`/`brainstorm` route through it.
- **Phase 1 ✅** Capability-gated model + skipped fallback; self-inlined `@file` with the symlink-aware guard; truthful sandbox notice; backend-aware detection/errors.
- **Phase 2 ✅** JSONL + SQLite transcript readers behind one interface (probing both the logs dir and `conversations/.db`); start-time-bounded discovery; JSONL→SQLite failover.
- **Phase 3 ✅** Output recovery is now a capability-aware ladder, best → last-resort, in `agyBackend.run`:
  1. **Clean JSON stdout** — `agyCapabilities.probeAgyCapabilities()` reads `agy --help` once per process (fail-safe, 4s timeout); if the build advertises `--output-format json` we pass it and parse the reply off stdout (`agyOutput.parseAgyJsonResponse`). No transcript touched.
  2. **Plain stdout** — used whenever non-empty, so the day `agy -p` prints reliably the fallback simply stops running.
  3. **PTY recovery (opt-in `AGY_MCP_PTY=1`, POSIX)** — runs `agy` under a pseudo-terminal via `script(1)` so a TTY-only build still streams real stdout, reading **no** private files (S1b). Best-effort; args POSIX-quoted so the non-PTY path's injection safety is preserved.
  4. **Transcript scrape** — the Phase 2 last resort.

  Because step 1 is driven by `agy --help`, the backend climbs the ladder on its own as upstream fixes print-mode — **no code change required**.
- **Phase 4 ✅** Date-aware cutover: `resolveDefaultBackend()` returns `gemini` until **2026-06-18** and `agy` thereafter (once gemini is retired, agy is the only live option), so the default flips automatically — no release needed on the day. `GEMINI_MCP_BACKEND` always overrides. `backendSelection()` emits a notice on the post-retirement auto-switch and a once-per-process nudge in the final countdown.

## Review hardening (full-diff review pass)

A full review of the branch surfaced and fixed five issues:

- **stdin routing on `agy`** — inlined `@file`/changeMode prompts carry whole files; passing them as a `-p` argv element exceeded OS command-line limits (E2BIG). They now ride on stdin, exactly like the gemini path (#27, #77).
- **Error-tolerant ladder** — a non-zero exit from `agy -p` (another known 1.0.x failure mode) now descends the recovery ladder instead of aborting the run; only ENOENT aborts immediately.
- **Bounded runs** — `executeCommand` gained a 20-minute default timeout, so a hung CLI can never permanently wedge the serialized agy queue (or the server).
- **Symlink guard on the gemini path too** — `assertSafeFileReferences` itself now realpath-checks in-root symlinks, closing the CVE-2026-0755 gap on the default backend (previously only agy's self-inlining had the re-check).
- **Windows resolution** — `%LOCALAPPDATA%\Antigravity` is now actually probed before giving up, matching the guidance the ENOENT message already gives.

Plus dedup: one shared `prepareChangeModePrompt()` for both backends (no drift), and one `replyFrom()` helper for the stdout/PTY parse.

## Config

| Variable | Purpose |
| --- | --- |
| `GEMINI_MCP_BACKEND` | `gemini` or `agy`/`antigravity`; unset uses the date-aware default |
| `AGY_CLI_PATH` | full path to the `agy` binary when it's off-PATH |
| `AGY_MCP_PTY` | `1` to enable opt-in PTY stdout recovery for `agy -p` (POSIX only) |

## Verification

`npm run build` clean · `npm run lint` clean · `npm test` → **94 passing** (was 77; +17 for the capability probe, JSON parsing, PTY helpers, date-aware cutover, command timeout, and the symlink guard). No default behaviour change before retirement — `gemini` users get identical output; notices appear only when a backend can't honor a request or the cutover date is near.

## Open questions

1. Does any `agy` version inline `@file`-style references, or must we always read files ourselves?
2. Is there a planner-only / no-tools print mode for safe read-only analysis?
3. What is the real headless output contract once `-p` stdout / `--output-format json` are fixed? (The capability probe already adapts when they land.)

Refs #90.