### PR TITLE
fix: retirement-aware missing-CLI guidance + README framing (affected vs enterprise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - On `agy`, `model` is not forwarded (print mode is Gemini 3.5 Flash-only) and the Pro to Flash fallback is skipped, with a notice. `@file` references are inlined by us so the CVE-2026-0755 project-root guard stays in the data path. A `sandbox` request returns a notice that print-mode `agy` does not isolate tool execution.
+- Missing-CLI guidance is retirement-aware: it names the 2026-06-18 cutover, gives the real `agy` install command, and tells Enterprise/API-key users to set `GEMINI_MCP_BACKEND=gemini` to stay on `gemini`.
 
 ### Fixed
 - agy: never recover a stale reply from a previous conversation when a print run fails fast (e.g. dropped auth); a transcript is trusted only when written during the run.

--- a/README.md
+++ b/README.md
@@ -27,22 +27,31 @@ This is a simple Model Context Protocol (MCP) server that allows AI assistants t
 ## Prerequisites
 
 <details>
-<summary>🚀 <strong>Important: `gemini` to `agy` Migration Notice</strong></summary>
+<summary>🚀 <strong>Important: Gemini CLI is retired. This tool now defaults to Antigravity CLI (`agy`)</strong></summary>
 
-Google is ending support for the Gemini CLI on **2026-06-18** for free, Pro, and Ultra users. **There is no grace period.** To prevent disruptions to your workflow, you must migrate to the new Antigravity CLI (`agy`) before this date:
+On **2026-06-18**, Google retired the Gemini CLI for **free, Google AI Pro, and Google AI Ultra** users (and individual Gemini Code Assist / GitHub-org users). Its successor is the **Antigravity CLI** (`agy`). See [Google's announcement](https://goo.gle/gemini-cli-migration).
 
+**From 2026-06-18 this tool selects the `agy` backend automatically.** If you are on an affected tier, just install `agy`:
 
-| Variable             | Purpose                                                              |
-| -------------------- | -------------------------------------------------------------------- |
-| `GEMINI_MCP_BACKEND` | `gemini` (default) or `agy`/`antigravity` to use the Antigravity CLI |
-| `AGY_CLI_PATH`       | Full path to the`agy` binary if it isn't on the server's PATH        |
+```bash
+curl -fsSL https://antigravity.google/cli/install.sh | bash   # macOS / Linux
+```
 
-The `agy` backend is **experimental**: print-mode is Gemini 3.5 Flash-only, replies are
-read from `agy`'s stdout (with transcript recovery only when stdout is empty), and tool
-execution isn't sandboxed in `-p`. The
-tool emits a notice whenever a requested `model` or `sandbox` can't be honored. See
-[docs/migration/antigravity-cli.md](docs/migration/antigravity-cli.md) for the full
-analysis and migration plan.
+Then run `agy` once to sign in. Nothing else to change.
+
+**Enterprise / Standard-license or paid-API-key user?** Your Gemini CLI access is **unaffected** by the retirement. To keep using it, set one env var on the MCP server:
+
+```bash
+GEMINI_MCP_BACKEND=gemini
+```
+
+| Variable | Purpose |
+| --- | --- |
+| `GEMINI_MCP_BACKEND` | `gemini` or `agy`/`antigravity`. Unset uses the date-aware default (`agy` from 2026-06-18). |
+| `AGY_CLI_PATH` | Full path to the `agy` binary if it isn't on the server's PATH. |
+| `GEMINI_MCP_TIMEOUT` | Overall CLI run timeout in minutes (default 45). |
+
+The `agy` backend is **experimental**: print mode is Gemini 3.5 Flash-only, replies come from `agy`'s stdout (transcript recovery only as a fallback), and tool execution isn't sandboxed in `-p`. The tool emits a notice when a requested `model`/`sandbox` can't be honored, and surfaces `agy`'s own errors (quota, auth) verbatim. Full analysis: [docs/migration/antigravity-cli.md](docs/migration/antigravity-cli.md).
 
 </details>
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -112,6 +112,9 @@ export const RETIREMENT = {
   GEMINI_CLI_ISO: "2026-06-18",
   // Days before retirement at which we start nudging callers to test agy.
   WARN_WITHIN_DAYS: 14,
+  // Real migration pointers Google surfaces in the gemini CLI itself.
+  AGY_INSTALL_CMD: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+  MIGRATION_URL: "https://goo.gle/gemini-cli-migration",
 } as const;
 
 

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -3,7 +3,7 @@ import { existsSync } from "fs";
 import os from "os";
 import path from "path";
 import { Logger } from "./logger.js";
-import { CLI, ENV } from "../constants.js";
+import { CLI, ENV, RETIREMENT } from "../constants.js";
 
 // Quote a single argument for cmd.exe (used by spawn's shell:true on Windows).
 // Embedded quotes are doubled and backslash runs before a quote (or the closing
@@ -93,24 +93,28 @@ export function resolveCommandForExecution(command: string): string {
 // common cause is the MCP server not inheriting the user's interactive PATH.
 export function buildEnoentErrorMessage(command: string): string {
   const isWindows = process.platform === "win32";
+  const installAgy = isWindows
+    ? `install it from ${RETIREMENT.MIGRATION_URL}`
+    : `run \`${RETIREMENT.AGY_INSTALL_CMD}\``;
   const lines = [
     `Could not find the "${command}" executable.`,
     `The MCP server runs in its own process and may not inherit your shell's PATH.`,
     `• Verify it is installed and resolvable: \`${isWindows ? "where" : "which"} ${command}\`.`,
   ];
-  if (command === CLI.COMMANDS.GEMINI) {
+  if (command === CLI.COMMANDS.AGY) {
     lines.push(
-      `• Install it: \`npm install -g @google/gemini-cli\`.`,
+      `• Antigravity CLI (agy) is the Gemini CLI's successor and this tool's default backend since ${RETIREMENT.GEMINI_CLI_ISO}. To install it, ${installAgy}, then run \`agy\` once to sign in.`,
       isWindows
-        ? `• Or set ${ENV.GEMINI_CLI_PATH} to the full path of the gemini shim (e.g. C:\\path\\to\\gemini.cmd).`
-        : `• Or set ${ENV.GEMINI_CLI_PATH} to the full path of the gemini executable.`,
+        ? `• It installs under %LOCALAPPDATA%\\Antigravity\\; add that to PATH or set ${ENV.AGY_CLI_PATH} to agy.exe.`
+        : `• It installs to ~/.local/bin; add that to PATH or set ${ENV.AGY_CLI_PATH} to the agy binary.`,
+      `• On a supported Gemini tier (paid API key or Enterprise/Standard license)? Set ${ENV.BACKEND}=gemini to keep using the Gemini CLI instead.`,
+      `• More: ${RETIREMENT.MIGRATION_URL} and docs/migration/antigravity-cli.md`,
     );
-  } else if (command === CLI.COMMANDS.AGY) {
+  } else if (command === CLI.COMMANDS.GEMINI) {
     lines.push(
-      `• agy ships with Google Antigravity; install it from https://antigravity.google and authenticate once with \`agy -i\`.`,
-      isWindows
-        ? `• It installs to %LOCALAPPDATA%\\Antigravity\\; add that to PATH or set ${ENV.AGY_CLI_PATH} to the full path of agy.exe.`
-        : `• It installs to ~/.local/bin; add that to PATH or set ${ENV.AGY_CLI_PATH} to the full path of the agy binary.`,
+      `• The Gemini CLI stopped serving free, Pro, and Ultra users on ${RETIREMENT.GEMINI_CLI_ISO}. Migrate to the Antigravity CLI (agy), this tool's new default: ${installAgy}, then unset ${ENV.BACKEND}.`,
+      `• Enterprise/Standard license or paid API key? Your Gemini access is unaffected: reinstall the Gemini CLI or set ${ENV.GEMINI_CLI_PATH} to its full path.`,
+      `• More: ${RETIREMENT.MIGRATION_URL} and docs/migration/antigravity-cli.md`,
     );
   }
   return lines.join("\n");

--- a/test/unit/utils/commandExecutor.test.ts
+++ b/test/unit/utils/commandExecutor.test.ts
@@ -47,17 +47,21 @@ describe("Node Utilities: Command Executor & Quoting", () => {
     );
   });
 
-  test("buildEnoentErrorMessage gives gemini-specific, platform-aware guidance", () => {
+  test("buildEnoentErrorMessage gives gemini retirement + migration guidance", () => {
     const msg = buildEnoentErrorMessage("gemini");
     assert.match(msg, /Could not find the "gemini"/);
-    assert.match(msg, /GEMINI_CLI_PATH/);
-    assert.match(msg, /@google\/gemini-cli/);
+    assert.match(msg, /2026-06-18/); // retirement date
+    assert.match(msg, /Antigravity|agy/i); // points at the successor
+    assert.match(msg, /GEMINI_CLI_PATH/); // override still offered for unaffected tiers
+    assert.doesNotMatch(msg, /npm install -g @google\/gemini-cli/); // dead advice removed
     assert.match(msg, process.platform === "win32" ? /where gemini/ : /which gemini/);
   });
 
-  test("buildEnoentErrorMessage omits the gemini install hint for other commands", () => {
+  test("buildEnoentErrorMessage points agy users to install + the gemini fallback env", () => {
     const msg = buildEnoentErrorMessage("agy");
     assert.match(msg, /Could not find the "agy"/);
+    assert.match(msg, /AGY_CLI_PATH/);
+    assert.match(msg, /GEMINI_MCP_BACKEND/); // how enterprise stays on gemini
     assert.doesNotMatch(msg, /@google\/gemini-cli/);
   });
 


### PR DESCRIPTION
## Summary

When a backend CLI is missing, the tool now fails *helpfully*: it names the 2026-06-18 Gemini CLI retirement, gives Google's real `agy` install command, and tells Enterprise / paid-API-key users how to stay on `gemini`. The README migration notice is reframed for both audiences. Folds into the still-unpublished 1.1.8.

## Changes

- `buildEnoentErrorMessage` is retirement-aware. It drops the dead `npm install -g @google/gemini-cli` advice. For a missing `agy` it gives `curl -fsSL https://antigravity.google/cli/install.sh | bash` plus sign-in and `AGY_CLI_PATH`, and notes Enterprise/API-key users can set `GEMINI_MCP_BACKEND=gemini`. For a missing `gemini` it points to the agy migration and notes that unaffected tiers keep access.
- README migration notice rewritten for two audiences: affected tiers (free/Pro/Ultra) install `agy` (now the default since 2026-06-18); Enterprise/Standard-license and paid-API-key users are unaffected and set `GEMINI_MCP_BACKEND=gemini` to stay on `gemini`. Real install command, dates, and announcement link.
- `RETIREMENT` constants gain the real install command and migration URL.
- Tests updated for the new messages (100 total).

## Verification

- [ ] `npm test` passes; `npm run build` clean
- [ ] `buildEnoentErrorMessage("agy")` and `("gemini")` print accurate, actionable guidance
- [ ] README notice renders with both the "affected tier" and "enterprise / API-key" paths
